### PR TITLE
generate_html_report.sh: Support generated suppressions in HTML report

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The `memcheck_runner.sh` script is a wrapper that will run a binary under Valgri
 
 #### Prerequisites
 
-For the `generate_html_report.sh` script to work, the following tools must be installed and accessible using the PATH environment variable:
+For the `memcheck_runner.sh` script to work, the following tools must be installed and accessible using the PATH environment variable:
   - `bash` Bash version 4 and upper only are supported.
   - `valgrind` Valgrind version 3.13 was tested, older version might not work as intended
 

--- a/bin/awk/format_memcheck_report.awk
+++ b/bin/awk/format_memcheck_report.awk
@@ -204,6 +204,16 @@
                   "\\1\\&nbsp;<span class=\"leak_context_info\">\\2</span>", 1, output)
 
     #############
+    ## Valgrind's suppression entry
+    #############
+
+    # Vagrind suppression opening
+    output=gensub(/^{$/, valgrind_suppression_opening "{", 1, output)
+
+    # Vagrind suppression closing (add two ==== lines to seperate the suppression from the next violation)
+    output=gensub(/^}$/, "}</div>====<br />====", 1, output)
+
+    #############
     ## Additionnal infos
     #############
 

--- a/bin/generate_html_report.sh
+++ b/bin/generate_html_report.sh
@@ -596,6 +596,14 @@ function generate_html_report()
         awk_memcheck_format_opt+=(-v "${opt}_client_check_criticality=${memcheck_client_check_criticality[${opt}],,}")
     done
 
+    # Add valgrind suppression header
+    local visibility_icon='<span class="suppression_visibility_icon"><div class="expand"><div></div></div></span>'
+    local valgrind_suppression_opening='<div class="suppression_title" onclick="javascript:ToogleSuppressionVisibility(this)">'
+    valgrind_suppression_opening+="${visibility_icon} Show generated suppression"
+    valgrind_suppression_opening+='</div><br /><div class="hidden suppression_content">'
+
+    awk_memcheck_format_opt+=(-v "valgrind_suppression_opening=${valgrind_suppression_opening}")
+
     local memcheck_input_dir_len=${#memcheck_input_dir}
 
     # Process each memcheck result file

--- a/bin/html_res/memcheck-cover.css
+++ b/bin/html_res/memcheck-cover.css
@@ -283,7 +283,7 @@ body {
     user-select: none;
 }
 
-/* Change the background color on hover for an additionnal hint the title can be clicked */
+/* Change the background color on hover as an additionnal hint the title can be clicked */
 .memcheck_analysis_title:hover {
     background-color: #F2F2FF;
 }
@@ -392,6 +392,49 @@ body {
     color: #222222; /* Dark grey */
     text-decoration: underline;
     text-decoration-thickness: 1px;
+}
+
+/* Valgrind suppressions */
+.suppression_title, .suppression_content {
+    color: #733B00; /* Brown */
+    background-color: #ffeec66e; /* Light yellow */
+    font-style: italic;
+    margin: 0px;
+    margin-left: 20px;
+    padding-top: 3px;
+    padding-bottom: 3px;
+    padding-left: 10px;
+    border: dashed thin #F08411; /* Orange dashed border */
+}
+
+.suppression_title {
+    font-size: 0.9em;
+    display: inline-block;
+    position: relative;
+    width: 255px;
+
+    /* Move this div 1px down so the borders merges into the content div's one */
+    top: 1px;
+
+    /* Enable pointer on hover to inform the user it can be clicked */
+    cursor: pointer;
+
+    /* Disable text selection to avoid double click selection */
+    user-select: none;
+}
+
+/* Change the background color on hover as an additionnal hint the title can be clicked */
+.suppression_title:hover {
+    background-color: #ffe7b0; /* Orangish yellow */
+}
+
+.suppression_visibility_icon {
+    position: relative;
+    top: 2px;
+}
+
+.suppression_content {
+    padding-right: 10px;
 }
 
 /* Vagrind warnings */

--- a/bin/html_res/memcheck-cover.js
+++ b/bin/html_res/memcheck-cover.js
@@ -160,7 +160,7 @@ function UpdateAnalysisVisibility(action, test_id)
             // Update the visibility image to the expand one
             visibility_span.innerHTML = "<div class=\"expand\"><div></div></div>";
 
-            // Remove the hidden class to the analysis content
+            // Add the hidden class to the analysis content
             analysis_div.className = "memcheck_analysis_content hidden";
         }
     }
@@ -171,8 +171,47 @@ function UpdateAnalysisVisibility(action, test_id)
             // Update the visibility image to the collapse one
             visibility_span.innerHTML = "<div class=\"collapse\"><div></div></div>";
 
-            // Add the hidden class to the analysis content
+            // Remove the hidden class to the analysis content
             analysis_div.className = "memcheck_analysis_content";
         }
     }
+}
+
+/**
+ * This function toggles the visibility of the violation suppression content
+ *
+ * @param titleDiv: The violation suppression "button" div that triggered the event
+ */
+function ToogleSuppressionVisibility(titleDiv)
+{
+    // Next siblig is a <br /> tag, the second next is the content
+    contentDiv = titleDiv.nextSibling.nextSibling;
+
+    actionToPerform = "";
+    visibilityClass = "";
+
+    if (contentDiv.className === "suppression_content")
+    {
+        actionToPerform = "Show";
+
+        // Update the visibility image to the expand one
+        visibilityClass = "expand";
+
+        // Add the hidden class to the suppression content
+        contentDiv.className = "suppression_content hidden";
+    }
+    else
+    {
+        actionToPerform = "Hide";
+
+        // Update the visibility image to the collapse one
+        visibilityClass = "collapse";
+
+        // Remove the hidden class to the suppression content
+        contentDiv.className = "suppression_content";
+    }
+
+    titleDiv.innerHTML = "<span class=\"suppression_visibility_icon\"><div class=\""
+                       + visibilityClass + "\"><div></div></div></span> "
+                       + actionToPerform + " generated suppression";
 }

--- a/tests/awk/shellcheck_errors_filter.awk
+++ b/tests/awk/shellcheck_errors_filter.awk
@@ -85,12 +85,12 @@ function print_buffers()
     }
     # `error_occured` is used by the caller
     else if (($0 ~ /\^-- SC2034: error_occured appears unused\. Verify it or export it\./) \
-             && (previous_lines[0] ~ /tests\/utils\.test\.sh line 276:/))
+             && (previous_lines[0] ~ /tests\/utils\.test\.sh line 277:/))
     {
     }
     # `useless_result` in only set to prevent evaluation of it's assigned sub-shell output
     else if (($0 ~ /\^-- SC2034: useless_result appears unused./) \
-             && (previous_lines[0] ~ /tests\/generate_html_outputs_ts\/ts_setup\.sh line 111:/))
+             && (previous_lines[0] ~ /tests\/generate_html_outputs_ts\/ts_setup\.sh line 139:/))
     {
     }
     # In tests, `test_cases` variable is declared and then processed by a function from utils.test.sh

--- a/tests/generate_html_outputs_ts/ref/violation_suppression_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/violation_suppression_report/index.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <link rel="stylesheet" type="text/css" href="memcheck-cover.css">
+        <script type="text/javascript" src="memcheck-cover.js"></script>
+
+        <!-- Vagrind reports asynchronous loading parts -->
+        <script src="uninitialized_value.memcheck.html.part" async="async"></script>
+    </head>
+    <body>
+        <div class="report_container">
+            <div class="report_header">
+                <div class="report_title">
+                    Valgrind's memcheck report
+                </div>
+                <div class="report_separator"></div>
+            </div>
+            <div class="report_content">
+                <div class="report_summary">
+                    <div class="report_summary_title">Result summary:</div>
+                    <div class="report_summary_ratio" title="Warnings: 1" style="background-image: linear-gradient(to right, #00CF00 0%, orange 0%, orange 100%, red 100%, red 100%);">
+                        Pass: 0 / 1
+                    </div>
+                    <div class="report_summary_warnings">Warnings: 5</div>
+                    <div class="report_summary_infos">Infos: 5</div>
+                    <br /><br />
+                    <div title="Expand all" onclick="JavaScript: ExpandAll();" class="expandall"><div></div><div></div><div></div></div>
+                    <div title="Collapse all" onclick="JavaScript: CollapseAll();" class="collapseall"><div></div><div></div><div></div></div>
+                    <div onclick="JavaScript: ToggleAnalysisTitleType();" id="analysis_title_type_button" class="analysis_title_type_button">Toggle title: Analysis name</div>
+                </div>
+                <div class="memcheck_analysis_title" onclick="JavaScript: ToggleAnalysisResultVisibility('valgrind.result1');">
+                    <span id="valgrind.result1.VisibilityIcon"><div class="expand"><div></div></div></span> <span class="brace_recenter">[</span><span class="analysis_warning_status">WARNING</span><span class="brace_recenter">]</span> <span id="valgrind.result1.Title.Cmd">Command: uninitialized_value</span><span id="valgrind.result1.Title.Name" class="hidden">Analysis name: uninitialized_value</span> <span class="analysis_type_infos"><div class="report_summary_warnings">Warnings: 5</div>
+                    <div class="report_summary_infos">Infos: 5</div></span>
+                </div>
+                <div id="valgrind.result1.Report" class="memcheck_analysis_content hidden">
+                    <span class="result_loader"></span><span class="result_loader_text"></span>
+                </div>
+            </div>
+            <div class="report_footer">
+                <div class="generation_tool_version">
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.0
+                </div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/tests/generate_html_outputs_ts/ref/violation_suppression_report/memcheck-cover.css
+++ b/tests/generate_html_outputs_ts/ref/violation_suppression_report/memcheck-cover.css
@@ -1,0 +1,1 @@
+../../../../bin/html_res/memcheck-cover.css

--- a/tests/generate_html_outputs_ts/ref/violation_suppression_report/memcheck-cover.js
+++ b/tests/generate_html_outputs_ts/ref/violation_suppression_report/memcheck-cover.js
@@ -1,0 +1,1 @@
+../../../../bin/html_res/memcheck-cover.js

--- a/tests/generate_html_outputs_ts/ref/violation_suppression_report/uninitialized_value.memcheck.html.part
+++ b/tests/generate_html_outputs_ts/ref/violation_suppression_report/uninitialized_value.memcheck.html.part
@@ -1,0 +1,111 @@
+async function updateContentOnceLoaded1()
+{
+    var data =`
+==1== Memcheck, a memory error detector<br />
+==1== Copyright (C), and GNU GPL'd, by Julian Seward et al.<br />
+==1== Using Valgrind and LibVEX; rerun with -h for copyright info<br />
+==1== Command: memcheck-cover/tests/bin/uninitialized_value/out/uninitialized_value<br />
+==1== Parent PID: 1<br />
+==1== <br />
+==1== <span class="warning_leak">Conditional jump or move depends on uninitialised value(s)</span><br />
+==1== &nbsp; &nbsp;at 0x10101042: breakage::evil_jump_on_stack_uninitialized_value() (<span class="leak_file_info">main.cpp:14</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">main.cpp:34</span>)<br />
+==1== <span class="leak_context_info">&nbsp;Uninitialised value was created by a stack allocation</span><br />
+==1== &nbsp; &nbsp;at 0x10101042: breakage::evil_jump_on_stack_uninitialized_value() (<span class="leak_file_info">main.cpp:5</span>)<br />
+==1== <br />
+<div class="suppression_title" onclick="javascript:ToogleSuppressionVisibility(this)"><span class="suppression_visibility_icon"><div class="expand"><div></div></div></span> Show generated suppression</div><br /><div class="hidden suppression_content">{<br />
+ &nbsp; &lt;insert_a_suppression_name_here&gt;<br />
+ &nbsp; Memcheck:Cond<br />
+ &nbsp; fun:_ZN8breakage38evil_jump_on_stack_uninitialized_valueEv<br />
+ &nbsp; fun:main<br />
+}</div>====<br />====<br />
+==1== <span class="warning_leak">Conditional jump or move depends on uninitialised value(s)</span><br />
+==1== &nbsp; &nbsp;at 0x10101042: std::ostreambuf_iterator&lt;char, std::char_traits&lt;char&gt; &gt; std::num_put&lt;char, std::ostreambuf_iterator&lt;char, std::char_traits&lt;char&gt; &gt; &gt;::_M_insert_int&lt;long&gt;(std::ostreambuf_iterator&lt;char, std::char_traits&lt;char&gt; &gt;, std::ios_base&amp;, char, long) const (in a_host_lib.so)<br />
+==1== &nbsp; &nbsp;by 0x10101042: std::ostream&amp; std::ostream::_M_insert&lt;long&gt;(long) (in a_host_lib.so)<br />
+==1== &nbsp; &nbsp;by 0x10101042: breakage::evil_use_of_uninitialized_value() (<span class="leak_file_info">main.cpp:26</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">main.cpp:35</span>)<br />
+==1== <span class="leak_context_info">&nbsp;Uninitialised value was created by a heap allocation</span><br />
+==1== &nbsp; &nbsp;at 0x10101042: operator new(unsigned long) (in a_host_lib.so)<br />
+==1== &nbsp; &nbsp;by 0x10101042: breakage::evil_use_of_uninitialized_value() (<span class="leak_file_info">main.cpp:23</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">main.cpp:35</span>)<br />
+==1== <br />
+<div class="suppression_title" onclick="javascript:ToogleSuppressionVisibility(this)"><span class="suppression_visibility_icon"><div class="expand"><div></div></div></span> Show generated suppression</div><br /><div class="hidden suppression_content">{<br />
+ &nbsp; &lt;insert_a_suppression_name_here&gt;<br />
+ &nbsp; Memcheck:Cond<br />
+ &nbsp; fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE13_M_insert_intIlEES3_S3_RSt8ios_basecT_<br />
+ &nbsp; fun:_ZNSo9_M_insertIlEERSoT_<br />
+ &nbsp; fun:_ZN8breakage31evil_use_of_uninitialized_valueEv<br />
+ &nbsp; fun:main<br />
+}</div>====<br />====<br />
+==1== <span class="warning_leak">Use of uninitialised value of size 42</span><br />
+==1== &nbsp; &nbsp;at 0x10101042: ??? (in a_host_lib.so)<br />
+==1== &nbsp; &nbsp;by 0x10101042: std::ostreambuf_iterator&lt;char, std::char_traits&lt;char&gt; &gt; std::num_put&lt;char, std::ostreambuf_iterator&lt;char, std::char_traits&lt;char&gt; &gt; &gt;::_M_insert_int&lt;long&gt;(std::ostreambuf_iterator&lt;char, std::char_traits&lt;char&gt; &gt;, std::ios_base&amp;, char, long) const (in a_host_lib.so)<br />
+==1== &nbsp; &nbsp;by 0x10101042: std::ostream&amp; std::ostream::_M_insert&lt;long&gt;(long) (in a_host_lib.so)<br />
+==1== &nbsp; &nbsp;by 0x10101042: breakage::evil_use_of_uninitialized_value() (<span class="leak_file_info">main.cpp:26</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">main.cpp:35</span>)<br />
+==1== <span class="leak_context_info">&nbsp;Uninitialised value was created by a heap allocation</span><br />
+==1== &nbsp; &nbsp;at 0x10101042: operator new(unsigned long) (in a_host_lib.so)<br />
+==1== &nbsp; &nbsp;by 0x10101042: breakage::evil_use_of_uninitialized_value() (<span class="leak_file_info">main.cpp:23</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">main.cpp:35</span>)<br />
+==1== <br />
+<div class="suppression_title" onclick="javascript:ToogleSuppressionVisibility(this)"><span class="suppression_visibility_icon"><div class="expand"><div></div></div></span> Show generated suppression</div><br /><div class="hidden suppression_content">{<br />
+ &nbsp; &lt;insert_a_suppression_name_here&gt;<br />
+ &nbsp; Memcheck:Value8<br />
+ &nbsp; obj:/path/to/a_host_lib.so<br />
+ &nbsp; fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE13_M_insert_intIlEES3_S3_RSt8ios_basecT_<br />
+ &nbsp; fun:_ZNSo9_M_insertIlEERSoT_<br />
+ &nbsp; fun:_ZN8breakage31evil_use_of_uninitialized_valueEv<br />
+ &nbsp; fun:main<br />
+}</div>====<br />====<br />
+==1== <span class="warning_leak">Conditional jump or move depends on uninitialised value(s)</span><br />
+==1== &nbsp; &nbsp;at 0x10101042: ??? (in a_host_lib.so)<br />
+==1== &nbsp; &nbsp;by 0x10101042: std::ostreambuf_iterator&lt;char, std::char_traits&lt;char&gt; &gt; std::num_put&lt;char, std::ostreambuf_iterator&lt;char, std::char_traits&lt;char&gt; &gt; &gt;::_M_insert_int&lt;long&gt;(std::ostreambuf_iterator&lt;char, std::char_traits&lt;char&gt; &gt;, std::ios_base&amp;, char, long) const (in a_host_lib.so)<br />
+==1== &nbsp; &nbsp;by 0x10101042: std::ostream&amp; std::ostream::_M_insert&lt;long&gt;(long) (in a_host_lib.so)<br />
+==1== &nbsp; &nbsp;by 0x10101042: breakage::evil_use_of_uninitialized_value() (<span class="leak_file_info">main.cpp:26</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">main.cpp:35</span>)<br />
+==1== <span class="leak_context_info">&nbsp;Uninitialised value was created by a heap allocation</span><br />
+==1== &nbsp; &nbsp;at 0x10101042: operator new(unsigned long) (in a_host_lib.so)<br />
+==1== &nbsp; &nbsp;by 0x10101042: breakage::evil_use_of_uninitialized_value() (<span class="leak_file_info">main.cpp:23</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">main.cpp:35</span>)<br />
+==1== <br />
+<div class="suppression_title" onclick="javascript:ToogleSuppressionVisibility(this)"><span class="suppression_visibility_icon"><div class="expand"><div></div></div></span> Show generated suppression</div><br /><div class="hidden suppression_content">{<br />
+ &nbsp; &lt;insert_a_suppression_name_here&gt;<br />
+ &nbsp; Memcheck:Cond<br />
+ &nbsp; obj:/path/to/a_host_lib.so<br />
+ &nbsp; fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE13_M_insert_intIlEES3_S3_RSt8ios_basecT_<br />
+ &nbsp; fun:_ZNSo9_M_insertIlEERSoT_<br />
+ &nbsp; fun:_ZN8breakage31evil_use_of_uninitialized_valueEv<br />
+ &nbsp; fun:main<br />
+}</div>====<br />====<br />
+==1== <span class="warning_leak">Conditional jump or move depends on uninitialised value(s)</span><br />
+==1== &nbsp; &nbsp;at 0x10101042: std::ostreambuf_iterator&lt;char, std::char_traits&lt;char&gt; &gt; std::num_put&lt;char, std::ostreambuf_iterator&lt;char, std::char_traits&lt;char&gt; &gt; &gt;::_M_insert_int&lt;long&gt;(std::ostreambuf_iterator&lt;char, std::char_traits&lt;char&gt; &gt;, std::ios_base&amp;, char, long) const (in a_host_lib.so)<br />
+==1== &nbsp; &nbsp;by 0x10101042: std::ostream&amp; std::ostream::_M_insert&lt;long&gt;(long) (in a_host_lib.so)<br />
+==1== &nbsp; &nbsp;by 0x10101042: breakage::evil_use_of_uninitialized_value() (<span class="leak_file_info">main.cpp:26</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">main.cpp:35</span>)<br />
+==1== <span class="leak_context_info">&nbsp;Uninitialised value was created by a heap allocation</span><br />
+==1== &nbsp; &nbsp;at 0x10101042: operator new(unsigned long) (in a_host_lib.so)<br />
+==1== &nbsp; &nbsp;by 0x10101042: breakage::evil_use_of_uninitialized_value() (<span class="leak_file_info">main.cpp:23</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">main.cpp:35</span>)<br />
+==1== <br />
+<div class="suppression_title" onclick="javascript:ToogleSuppressionVisibility(this)"><span class="suppression_visibility_icon"><div class="expand"><div></div></div></span> Show generated suppression</div><br /><div class="hidden suppression_content">{<br />
+ &nbsp; &lt;insert_a_suppression_name_here&gt;<br />
+ &nbsp; Memcheck:Cond<br />
+ &nbsp; fun:_ZNKSt7num_putIcSt19ostreambuf_iteratorIcSt11char_traitsIcEEE13_M_insert_intIlEES3_S3_RSt8ios_basecT_<br />
+ &nbsp; fun:_ZNSo9_M_insertIlEERSoT_<br />
+ &nbsp; fun:_ZN8breakage31evil_use_of_uninitialized_valueEv<br />
+ &nbsp; fun:main<br />
+}</div>====<br />====<br />
+==1== <br />
+==1== <span class="valgrind_summary_title">HEAP SUMMARY:</span><br />
+==1== &nbsp; &nbsp; in use at exit: 0 bytes in 0 blocks<br />
+==1== &nbsp; total heap usage: 3 allocs, 3 frees, 76,804 bytes allocated<br />
+==1== <br />
+==1== All heap blocks were freed -- no leaks are possible<br />
+==1== <br />
+==1== For counts of detected and suppressed errors, rerun with: -v<br />
+==1== <span class="valgrind_summary_title">ERROR SUMMARY:</span> 5 errors from 5 contexts (suppressed: 0 from 0)<br />
+`;
+    var analysis_div = document.getElementById('valgrind.result1.Report');
+    analysis_div.innerHTML=data;
+}
+updateContentOnceLoaded1();

--- a/tests/generate_html_outputs_ts/violation_suppression_report_ts_tc.sh
+++ b/tests/generate_html_outputs_ts/violation_suppression_report_ts_tc.sh
@@ -1,0 +1,60 @@
+#! /usr/bin/env bash
+
+resolved_script_path=$(readlink -f "$0")
+current_script_dir=$(dirname "${resolved_script_path}")
+current_full_path=$(readlink -e "${current_script_dir}")
+
+test_utils_import=$(readlink -e "${current_full_path}/../utils.test.sh")
+source "${test_utils_import}"
+
+############
+### TEST ###
+############
+
+function setup_test()
+{
+    local test_out_dir=$(get_test_outdir)
+    local testsuite_setup_out_dir=$(get_testsuite_setup_outdir)
+
+    # Create output dir if needed
+    [ ! -d "${test_out_dir}" ] && mkdir -p "${test_out_dir}"
+
+    cp "${testsuite_setup_out_dir}suppressions/"*.memcheck "${test_out_dir}"
+}
+
+function test_violation_suppression_report()
+{
+    local test_out_dir=$(get_test_outdir)
+    local generate_html_report="$(get_tools_bin_dir)/generate_html_report.sh"
+
+    local test_std_output="${test_out_dir}test.out"
+    local test_err_output="${test_out_dir}test.err.out"
+
+    local test_ref_report_dir="${current_full_path}/ref/violation_suppression_report/"
+    local report_out_dir="${test_out_dir}report/"
+
+    # Call the html report generator with the ${test_out_dir} as input directory
+    # and the ${report_out_dir} as output directory
+    "$generate_html_report" -i "${test_out_dir}" -o "${report_out_dir}" > "${test_std_output}" 2> "${test_err_output}"
+    local test_exit_code=$?
+
+    ### Check test output
+
+    # Compare report output with reference reports
+    expect_content_to_match "${test_ref_report_dir}" "${report_out_dir}"
+
+    expect_empty_file "${test_err_output}"
+
+    expect_exit_code $test_exit_code 0
+}
+
+# Init global
+error_occured=0
+
+# Setup test
+setup_test
+
+# Run test
+test_violation_suppression_report
+
+exit $error_occured

--- a/tests/utils.test.sh
+++ b/tests/utils.test.sh
@@ -47,8 +47,9 @@ function anonymize_memcheck_file()
     anonymize_sed_cmd+=";s# ${test_bin_dir// /\\\\ }# memcheck-cover/tests/bin#g"
 
     # Remove host specific lib path and version
-    anonymize_sed_cmd+=";s#(in \(.*/\)\?\(.*\.so\)\([.0-9]*\)\?)#(in a_host_lib.so)#g"
+    anonymize_sed_cmd+=";s#(in \(.*/\)\?.*\.so\([.0-9]*\)\?)#(in a_host_lib.so)#g"
     anonymize_sed_cmd+=";s#\( at 0x[A-Fa-f0-9]*: ??? (in\) [-/a-z0-9]*)#\1 /path/to/memcheck)#g"
+    anonymize_sed_cmd+=";s#^\([ ]* obj:\)\(\(.*/\)\?.*\.so\([.0-9]*\)\?\)#\1/path/to/a_host_lib.so#g"
 
     # Remove glibc version specific file line (templates from headers)
     anonymize_sed_cmd+=";s#(unique_ptr\.h:[0-9]*)#(unique_ptr\.h:42)#g"


### PR DESCRIPTION
The suppressions generated by Valgrind are now encapsulated into an
hidden div.
A button is displayed on top of each one to show or hide back the div.

A light yellow background color and a dotted border are used for both
the title and the content divs.

---

Added the related `violation_suppression_report` test to the
`generate_html_outputs` test-suite.