### PR TITLE
generate_html_report.sh: Support path without trailing slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Here is a generation example, with the following tree:
 ```
 my/output/path/
 ├── another_dir/
-│   └── a_report.memcheck
+│   ├── a_report.memcheck
 │   └── other_report.memcheck
 └── filename.memcheck
 ```
@@ -177,13 +177,13 @@ Info: Processing memcheck file 'another_dir/other_report.memcheck' ...
 Info: Generating index.html...
 ```
 
-The result will look like:
+The result will look like this:
 ```
 my/output/path/report/
 ├── another_dir/
-│   └── a_report.memcheck.html.part
+│   ├── a_report.memcheck.html.part
 │   └── other_report.memcheck.html.part
-└── filename.memcheck.html.part
+├── filename.memcheck.html.part
 ├── index.html
 ├── memcheck-cover.css
 └── memcheck-cover.js

--- a/bin/generate_html_report.sh
+++ b/bin/generate_html_report.sh
@@ -738,7 +738,7 @@ if [ ! -d "${memcheck_input_dir}" ]; then
     exit 1
 fi
 
-# -e test returns false if /path/to/a exists but is not a dir if it has a trailing /
+# -e test returns false if /path/to/a exists but is not a dir and has a trailing /
 html_output_dir_not_trailling="${html_output_dir}"
 if [ "${html_output_dir_not_trailling: -1}" == "/" ]; then
     html_output_dir_not_trailling="${html_output_dir_not_trailling:0:-1}"
@@ -747,6 +747,15 @@ fi
 if [ -e "${html_output_dir_not_trailling}" ] && [ ! -d "${html_output_dir}" ]; then
     error "Provided output directory '${html_output_dir}' exists but is not a directory"
     exit 1
+fi
+
+# Make sure input and output directories ends with a /
+if [ "${memcheck_input_dir: -1}" != "/" ]; then
+    memcheck_input_dir+="/"
+fi
+
+if [ "${html_output_dir: -1}" != "/" ]; then
+    html_output_dir+="/"
 fi
 
 ################################################

--- a/bin/utils.common.sh
+++ b/bin/utils.common.sh
@@ -18,8 +18,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ######
 
-# Enable colors only if in interactive shell
-if [ -t 1 ]; then
+# Enable colors only if in interactive shell or if asked for
+if [ -t 1 ] || [ "${memcheck_cover_always_use_colors}" == "true" ]; then
     RESET_FORMAT=$(echo -e '\e[00m')
     BOLD=$(echo -e '\e[1m')
     RED=$(echo -e '\e[31m')

--- a/tests/awk/shellcheck_errors_filter.awk
+++ b/tests/awk/shellcheck_errors_filter.awk
@@ -64,6 +64,16 @@ function print_buffers()
                  || (previous_lines[0] ~ /bin\/generate_html_report\.sh line 55:/)))
     {
     }
+    # `memcheck_cover_always_use_colors` might be set by utils.common.sh users to force color output
+    else if (($0 ~ /\^-- SC2154: memcheck_cover_always_use_colors is referenced but not assigned\./) \
+             && (previous_lines[0] ~ /bin\/utils.common\.sh line 22:/))
+    {
+    }
+    # The `memcheck_cover_always_use_colors` variable can be set to "true" before sourcing utils.common.sh to force color output
+    else if (($0 ~ /\^-- SC2034: memcheck_cover_always_use_colors appears unused\./) \
+             && (previous_lines[0] ~ /\/tests\/.+\.sh line [0-9]+:/))
+    {
+    }
     # Those elements are defined in utils.common.sh but used by the ones importing it
     else if ((($0 ~ /\^-- SC2034: memcheck_result_ext appears unused\. Verify it or export it\./) \
               || ($0 ~ /\^-- SC2034: BOLD appears unused\. Verify it or export it\./) \
@@ -75,38 +85,38 @@ function print_buffers()
     }
     # This call to a sub-shell is intended to
     else if (($0 ~ /\^-- SC2091: Remove surrounding \$\(\) to avoid executing output./) \
-             && (previous_lines[0] ~ /tests\/generate_html_params_ts\/generate_config_param_ts_ptc\.sh line 41:/))
+             && (previous_lines[0] ~ /\/tests\/generate_html_params_ts\/generate_config_param_ts_ptc\.sh line 41:/))
     {
     }
     # `test_cases` is set by the caller
     else if (($0 ~ /\^-- SC2154: test_cases is referenced but not assigned \(did you mean 'test_case'\?\)\./) \
-             && (previous_lines[0] ~ /tests\/utils\.test\.sh line 26:/))
+             && (previous_lines[0] ~ /\/tests\/utils\.test\.sh line 26:/))
     {
     }
     # `error_occured` is used by the caller
     else if (($0 ~ /\^-- SC2034: error_occured appears unused\. Verify it or export it\./) \
-             && (previous_lines[0] ~ /tests\/utils\.test\.sh line 277:/))
+             && (previous_lines[0] ~ /\/tests\/utils\.test\.sh line 277:/))
     {
     }
     # `useless_result` in only set to prevent evaluation of it's assigned sub-shell output
     else if (($0 ~ /\^-- SC2034: useless_result appears unused./) \
-             && (previous_lines[0] ~ /tests\/generate_html_outputs_ts\/ts_setup\.sh line 139:/))
+             && (previous_lines[0] ~ /\/tests\/generate_html_outputs_ts\/ts_setup\.sh line 139:/))
     {
     }
     # In tests, `test_cases` variable is declared and then processed by a function from utils.test.sh
     else if (($0 ~ /\^-- SC2034: test_cases appears unused\./) \
-             && (previous_lines[0] ~ /tests\/[^\/]+\/.+\.sh line [0-9]+:/))
+             && (previous_lines[0] ~ /\/tests\/[^\/]+\/.+\.sh line [0-9]+:/))
     {
     }
-    # In tests, `param_to_test` is voluntarily not quote to check space behaviour
+    # In tests, `param_to_test` is voluntarily not quoted to check space behaviour
     else if (($0 ~ /\^-- SC2086: Double quote to prevent globbing and word splitting\./) \
-             && (previous_lines[0] ~ /tests\/[^\/]+\/.+\.sh line [0-9]+:/) \
+             && (previous_lines[0] ~ /\/tests\/[^\/]+\/.+\.sh line [0-9]+:/) \
              && (previous_lines[1] ~ / \$\{param_to_test\}/))
     {
     }
-    # In tests, `in_dir_param` and `out_dir_param` are voluntarily not quote to check space behaviour
+    # In tests, `in_dir_param` and `out_dir_param` are voluntarily not quoted to check space behaviour
     else if (($0 ~ /\^-- SC2086: Double quote to prevent globbing and word splitting\./) \
-             && (previous_lines[0] ~ /tests\/generate_html_params_ts\/in_dir_out_dir_param_ts_ptc\.sh line 73:/))
+             && (previous_lines[0] ~ /\/tests\/generate_html_params_ts\/in_dir_out_dir_param_ts_ptc\.sh line 73:/))
     {
     }
     else

--- a/tests/generate_html_outputs_ts/many_result_report_ts_tc.sh
+++ b/tests/generate_html_outputs_ts/many_result_report_ts_tc.sh
@@ -27,7 +27,6 @@ function setup_test()
     # Move the 'invalid_delete' result to another sub-directory
     [ ! -d "${test_out_dir}z/test/bin/" ] && mkdir -p "${test_out_dir}z/test/bin/"
     mv "${test_out_dir}test/bin/invalid_delete.memcheck" "${test_out_dir}z/test/bin/"
-
 }
 
 function test_many_result_report()
@@ -43,7 +42,7 @@ function test_many_result_report()
 
     # Call the html report generator with the ${test_out_dir} as input directory
     # and the ${report_out_dir} as output directory
-    "$generate_html_report" -i "${test_out_dir}" -o "${report_out_dir}" > "${test_std_output}" 2> "${test_err_output}"
+    "${generate_html_report}" -i "${test_out_dir}" -o "${report_out_dir}" > "${test_std_output}" 2> "${test_err_output}"
     local test_exit_code=$?
 
     ### Check test output

--- a/tests/generate_html_outputs_ts/relative_path_report_ts_ptc.sh
+++ b/tests/generate_html_outputs_ts/relative_path_report_ts_ptc.sh
@@ -1,0 +1,127 @@
+#! /usr/bin/env bash
+
+test_parameter=$1
+
+resolved_script_path=$(readlink -f "$0")
+current_script_dir=$(dirname "${resolved_script_path}")
+current_full_path=$(readlink -e "${current_script_dir}")
+
+test_utils_import=$(readlink -e "${current_full_path}/../utils.test.sh")
+source "${test_utils_import}"
+
+# List all available test bin as test-cases
+test_cases=(
+    "relative_path"
+    "relative_path_no_leading_slash"
+    "current_dir_in_path"
+    "current_dir_in_path_no_leading_slash"
+    "current_dir_out_path"
+    "current_dir_out_path_no_leading_slash"
+)
+
+list_test_cases_option "$1"
+
+############
+### TEST ###
+############
+
+function setup_test()
+{
+    local test_out_dir=$(get_test_outdir)
+    local testsuite_setup_out_dir=$(get_testsuite_setup_outdir)
+
+    # Create output dir if needed
+    [ ! -d "${test_out_dir}test/bin/" ] && mkdir -p "${test_out_dir}test/bin/"
+
+    cp "${testsuite_setup_out_dir}"*.memcheck "${test_out_dir}test/bin/"
+
+    # Move back the 'true' result to the root directory
+    mv "${test_out_dir}test/bin/true.memcheck" "${test_out_dir}"
+
+    # Move the 'invalid_delete' result to another sub-directory
+    [ ! -d "${test_out_dir}z/test/bin/" ] && mkdir -p "${test_out_dir}z/test/bin/"
+    mv "${test_out_dir}test/bin/invalid_delete.memcheck" "${test_out_dir}z/test/bin/"
+}
+
+function error_and_exit()
+{
+    local error_message=$1
+
+    error "${error_message}"
+    exit 1
+}
+
+function test_relative_path_report()
+{
+    local test_type=$1
+
+    local test_out_dir=$(get_test_outdir)
+    local generate_html_report="$(get_tools_bin_dir)/generate_html_report.sh"
+
+    local test_std_output="${test_out_dir}test.out"
+    local test_err_output="${test_out_dir}test.err.out"
+
+    local test_ref_report_dir="${current_full_path}/ref/many_result_report/"
+    local report_out_dir="${test_out_dir}${test_type}/report/"
+
+    # Compute parameters
+    local report_generation_dir=""
+    local report_in_dir_param=""
+    local report_out_dir_param=""
+
+    # Move to the base-dir for "relative_path" tests
+    if [[ "${test_type}" == "relative_path"* ]]; then
+        report_generation_dir=$(dirname "${test_out_dir}")
+        report_in_dir_param=$(basename "${test_out_dir}")
+        report_out_dir_param="${report_in_dir_param}/${test_type}/report"
+    # Use current dir for "current_dir_in_path" tests
+    elif [[ "${test_type}" == "current_dir_in_path"* ]]; then
+        report_generation_dir="${test_out_dir}"
+        report_in_dir_param="."
+        report_out_dir_param="${test_type}/report/"
+    else
+        # Use the report dir for "current_dir_out_path" tests
+        report_generation_dir="${report_out_dir}"
+        report_in_dir_param="../.."
+        report_out_dir_param="."
+
+        # Report outdir needs to exist
+        [ ! -d "${report_out_dir}" ] && mkdir -p "${report_out_dir}"
+    fi
+
+    if [[ "${test_type}" != *"_no_leading_slash" ]]; then
+        report_in_dir_param+="/"
+        report_out_dir_param+="/"
+    fi
+
+    # Move to the appropriate directory
+    cd "${report_generation_dir}" > /dev/null || error_and_exit "Could not move to '${report_generation_dir}' directory"
+
+    # Call the html report generator with the ${report_in_dir_param} as input directory
+    # and the ${report_out_dir_param} as output directory
+    "${generate_html_report}" -i "${report_in_dir_param}" -o "${report_out_dir_param}" > "${test_std_output}" 2> "${test_err_output}"
+    local test_exit_code=$?
+
+    # Restore directory
+    cd - > /dev/null || error_and_exit "Could not move to back to the initial directory"
+
+    ### Check test output
+
+    # Compare report output with reference reports
+    expect_content_to_match "${test_ref_report_dir}" "${report_out_dir}"
+
+    expect_empty_file "${test_err_output}"
+
+    expect_exit_code $test_exit_code 0
+}
+
+# Init global
+error_occured=0
+
+# Setup test
+setup_test
+
+# Run test
+test_relative_path_report "${test_parameter}"
+
+exit $error_occured

--- a/tests/run_shellcheck.sh
+++ b/tests/run_shellcheck.sh
@@ -24,6 +24,11 @@ current_full_path=$(readlink -e "${current_script_dir}")
 
 root_dir=$(readlink -e "${current_full_path}/../")
 
+# Force colored output in github-ci
+if [ "${GITHUB_RUN_ID}" != "" ]; then
+    memcheck_cover_always_use_colors="true"
+fi
+
 # Import common utils
 source "${root_dir}/bin/utils.common.sh"
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -24,6 +24,11 @@ current_full_path=$(readlink -e "${current_script_dir}")
 
 bin_dir=$(readlink -e "${current_full_path}/../bin/")
 
+# Force colored output in github-ci
+if [ "${GITHUB_RUN_ID}" != "" ]; then
+    memcheck_cover_always_use_colors="true"
+fi
+
 # Import common utils
 source "${bin_dir}/utils.common.sh"
 

--- a/tests/utils.test.sh
+++ b/tests/utils.test.sh
@@ -316,5 +316,10 @@ function testsuite_setup_end()
     info "Done"
 }
 
+# Force colored output in github-ci
+if [ "${GITHUB_RUN_ID}" != "" ]; then
+    memcheck_cover_always_use_colors="true"
+fi
+
 # Source common utils from tools bin directory
 source "$(get_tools_bin_dir)/utils.common.sh"


### PR DESCRIPTION
Passing a path without an ending slash could result in incorrect
index.html generation.

If the provided path does not end with a slash, it's now added.

---

Added the following related tests to the `generate_html_outputs`
test-suite:
  - relative_path_report(relative_path)
  - relative_path_report(relative_path_no_leading_slash)
  - relative_path_report(current_dir_in_path)
  - relative_path_report(current_dir_in_path_no_leading_slash)
  - relative_path_report(current_dir_out_path)
  - relative_path_report(current_dir_out_path_no_leading_slash)

This test-suite covers both relative paths and non-slash ending paths as
parameter values.

The special "." and ".." values are tested as well.

---

This commit fixes #7