### PR TITLE
Add version control server link support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ All notable changes to the Memcheck-Cover project will be documented in this fil
   - Add support for path prefix substitution to the `generate_html_report.sh` script (issue [#15](https://github.com/Farigh/memcheck-cover/issues/15))
 
 **Enhancements:**
-  - Reduced header size
-  - Improved dark theme (Process termination and host stacktrace titles are now more visible)
+  - Reduced the report header size
+  - Improved the report dark themes (Process termination and host stacktrace titles are now more visible)
   - Reworked the report title selection to match the theme selection style
 
 **Fixed bugs:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the Memcheck-Cover project will be documented in this fil
 **New features:**
   - Add support for Valgrind's `--fullpath-after` option to the `memcheck_runner.sh` script
   - Add support for path prefix substitution to the `generate_html_report.sh` script (issue [#15](https://github.com/Farigh/memcheck-cover/issues/15))
+  - Add support for version control server link to the `generate_html_report.sh` script (issue [#16](https://github.com/Farigh/memcheck-cover/issues/16))
 
 **Enhancements:**
   - Reduced the report header size

--- a/README.md
+++ b/README.md
@@ -257,3 +257,44 @@ To:
 Multiple replacements can be defined
 
 :warning: The source path needs to be displayed for this to work (see [Display source fullpath](#small_blue_diamond-display-sources-fullpath))
+
+##### :small_blue_diamond: Source control server link generation
+
+This option is only available through the configuration file (see **-g|--generate-config** option).
+
+It can be defined by filling the following associative arrays (both are needed):
+```shell
+memcheck_url_prefix_replacement["<path_prefix>"]="<repository_url_prefix>"
+memcheck_url_prefix_replacement_type["<path_prefix>"]="<repository_type>"
+```
+
+Where the key `path_prefix` is the file path prefix to the repository root directory.
+
+The value `repository_url_prefix` is the source control server prefix to the repository.
+Here are some example:
+  - Github: https://github.com/example/example_project/blob/master/
+  - GitLab: https://gitlab.com/example/example_project/-/blob/master/
+  - BitBucket: http://bitbucket.org/example/example_project/src/master/
+
+And the value `repository_type` is one of the supported server type (case does not matter):
+  - GitHub
+  - GitLab
+  - BitBucket
+
+:warning: It's advised to set a link pointing to a specific commit sha1 instead of a branch so the links would always points to a meaningful line.
+
+For example, setting:
+```shell
+memcheck_url_prefix_replacement["/var/user/repo/"]="https://github.com/example/example_project/blob/master/"
+memcheck_url_prefix_replacement_type["/var/user/repo/"]="github"
+```
+
+Would convert the following report line:
+```text
+==1==    at 0x10101042: myFunc() (/var/user/repo/src/lib1/MyClass.cpp:14)
+```
+
+To:
+```
+==1==    at 0x10101042: myFunc() (<a href="https://github.com/example/example_project/blob/master/src/lib1/MyClass.cpp#L14">/var/user/repo/src/lib1/MyClass.cpp:14</a>)
+```

--- a/bin/awk/format_memcheck_report.awk
+++ b/bin/awk/format_memcheck_report.awk
@@ -46,8 +46,8 @@ function substitute_path_prefixes(str)
     output = str
 
     for (prefix in path_prefix_replacement) {
-        regex = "^(==[0-9]*== .* )\\(" prefix "([^:]*:[0-9]*)\\)(.*)$"
-        output = gensub(regex, "\\1 (" path_prefix_replacement[prefix] "\\2)\\3", 1, output)
+        regex = "^(==[0-9]*== .* \\()" prefix "([^:]*:[0-9]*)(\\).*)$"
+        output = gensub(regex, "\\1" path_prefix_replacement[prefix] "\\2\\3", 1, output)
     }
 
     return output

--- a/bin/html_res/memcheck-cover.css
+++ b/bin/html_res/memcheck-cover.css
@@ -867,7 +867,6 @@ body {
 .leak_file_info {
     color: var(--analysis-file-info-color);
     font-style: italic;
-    text-decoration: underline;
 }
 
 /* Leak program exit and valgrind program stacktrace */

--- a/tests/awk/shellcheck_errors_filter.awk
+++ b/tests/awk/shellcheck_errors_filter.awk
@@ -61,7 +61,7 @@ function print_buffers()
     # `memcheck_result_ext` is set by utils.common.sh
     else if (($0 ~ /\^-- SC2154: memcheck_result_ext is referenced but not assigned\./) \
              && ((previous_lines[0] ~ /bin\/memcheck_runner\.sh line 50:/) \
-                 || (previous_lines[0] ~ /bin\/generate_html_report\.sh line 57:/))) {
+                 || (previous_lines[0] ~ /bin\/generate_html_report\.sh line 59:/))) {
     }
     # `memcheck_cover_always_use_colors` might be set by utils.common.sh users to force color output
     else if (($0 ~ /\^-- SC2154: memcheck_cover_always_use_colors is referenced but not assigned\./) \
@@ -93,8 +93,10 @@ function print_buffers()
     }
     # `useless_result` in only set to prevent evaluation of it's assigned sub-shell output
     else if (($0 ~ /\^-- SC2034: useless_result appears unused./) \
-             && ((previous_lines[0] ~ /\/tests\/generate_html_outputs_ts\/ts_setup\.sh line 146:/) \
-                 || (previous_lines[0] ~ /\/tests\/generate_html_outputs_ts\/path_prefix_substitution_ts_ptc\.sh line 37:/))) {
+             && ((previous_lines[0] ~ /\/tests\/generate_html_outputs_ts\/ts_setup\.sh line 148:/) \
+                 || (previous_lines[0] ~ /\/tests\/generate_html_outputs_ts\/combined_path_substitution_and_url_link_ts_tc\.sh line 23:/) \
+                 || (previous_lines[0] ~ /\/tests\/generate_html_outputs_ts\/path_prefix_substitution_ts_ptc\.sh line 37:/) \
+                 || (previous_lines[0] ~ /\/tests\/generate_html_outputs_ts\/path_url_link_generation_ts_ptc\.sh line 38:/))) {
     }
     # In tests, `test_cases` variable is declared and then processed by a function from utils.test.sh
     else if (($0 ~ /\^-- SC2034: test_cases appears unused\./) \

--- a/tests/generate_html_outputs_ts/combined_path_substitution_and_url_link_ts_tc.sh
+++ b/tests/generate_html_outputs_ts/combined_path_substitution_and_url_link_ts_tc.sh
@@ -1,0 +1,90 @@
+#! /usr/bin/env bash
+
+resolved_script_path=$(readlink -f "$0")
+current_script_dir=$(dirname "${resolved_script_path}")
+current_full_path=$(readlink -e "${current_script_dir}")
+
+test_utils_import=$(readlink -e "${current_full_path}/../utils.test.sh")
+source "${test_utils_import}"
+
+############
+### TEST ###
+############
+
+function setup_test()
+{
+    local test_out_dir=$(get_test_outdir)
+    local generate_html_report="$(get_tools_bin_dir)/generate_html_report.sh"
+
+    # Create output dir if needed
+    [ ! -d "${test_out_dir}" ] && mkdir -p "${test_out_dir}"
+
+    # Create config files
+    local useless_result=$(cd "${test_out_dir}" && "${generate_html_report}" -g)
+    local config_file="${test_out_dir}memcheck-cover.config"
+    expect_file "${config_file}"
+
+    # Create output dir if needed
+    [ ! -d "${test_out_dir}" ] && mkdir -p "${test_out_dir}"
+
+    {
+        # Path prefix substitution
+        echo "memcheck_path_prefix_replacement[\"/var/user/git_repos/computation_libs\"]=\"[deps / computation]\""
+        echo "memcheck_path_prefix_replacement[\"/var/user/git_repos/my_proj\"]=\"[my proj]\""
+        echo "memcheck_path_prefix_replacement[\"/var/user/git_repos/another_libs\"]=\"[deps / another lib]\""
+
+        # Source control link generation
+        echo "memcheck_url_prefix_replacement[\"/var/user/git_repos/computation_libs/\"]=\"http://mygithub.io/example/example_project/blob/master/\""
+        echo "memcheck_url_prefix_replacement[\"/var/user/git_repos/my_proj/\"]=\"http://mygitlab.io/example/example_project/-/blob/master/\""
+        echo "memcheck_url_prefix_replacement[\"/var/user/git_repos/another_libs/\"]=\"http://mybitbucket.io/example/example_project/src/master/\""
+        echo "memcheck_url_prefix_replacement_type[\"/var/user/git_repos/computation_libs/\"]=\"github\""
+        echo "memcheck_url_prefix_replacement_type[\"/var/user/git_repos/my_proj/\"]=\"gitlab\""
+        echo "memcheck_url_prefix_replacement_type[\"/var/user/git_repos/another_libs/\"]=\"bitbucket\""
+    } >> "${config_file}"
+
+    # Copy memcheck report if not already done
+    local test_resx_dir=$(get_test_resources_dir)
+    cp "${test_resx_dir}fake_multiple_path_report.memcheck" "${test_out_dir}"
+}
+
+function test_combined_path_substitution_and_url_link()
+{
+    local test_out_dir=$(get_test_outdir)
+    local generate_html_report="$(get_tools_bin_dir)/generate_html_report.sh"
+
+    local test_std_output="${test_out_dir}test.out"
+    local test_err_output="${test_out_dir}test.err.out"
+
+    local test_ref_report_dir="${current_full_path}/ref/combined_path_substitution_and_url_link_report/"
+    local report_out_dir="${test_out_dir}report/"
+
+    local config_file="${test_out_dir}memcheck-cover.config"
+
+    # Call the html report generator with the ${test_out_dir} as input directory
+    # and the ${report_out_dir} as output directory
+    "${generate_html_report}" -i "${test_out_dir}" -o "${report_out_dir}" -c "${config_file}" > "${test_std_output}" 2> "${test_err_output}"
+    local test_exit_code=$?
+
+    ### Check test output
+
+    # Expect HTML part files
+    expect_file "${report_out_dir}fake_multiple_path_report.memcheck.html.part.js"
+
+    # Compare report output with reference reports
+    expect_content_to_match "${test_ref_report_dir}" "${report_out_dir}"
+
+    expect_empty_file "${test_err_output}"
+
+    expect_exit_code $test_exit_code 0
+}
+
+# Init global
+error_occured=0
+
+# Setup test
+setup_test
+
+# Run test
+test_combined_path_substitution_and_url_link
+
+exit $error_occured

--- a/tests/generate_html_outputs_ts/path_prefix_substitution_ts_ptc.sh
+++ b/tests/generate_html_outputs_ts/path_prefix_substitution_ts_ptc.sh
@@ -37,29 +37,29 @@ function setup_test()
     local useless_result=$(cd "${test_case_out_dir}" && "${generate_html_report}" -g)
     local config_file="${test_case_out_dir}memcheck-cover.config"
     expect_file "${config_file}"
-	
+
     if [ "${test_case}" == "with_substitution_lt_and_gt" ]; then
 		{
-			echo "memcheck_path_prefix_replacement[\"/var/user/git_repos/computation_libs\"]=\"<computation libs>\"" 
-			echo "memcheck_path_prefix_replacement[\"/var/user/git_repos/my_proj\"]=\"<my proj>\"" 
-			echo "memcheck_path_prefix_replacement[\"/var/user/git_repos/another_libs\"]=\"<another lib>\"" 
+			echo "memcheck_path_prefix_replacement[\"/var/user/git_repos/computation_libs\"]=\"<computation libs>\""
+			echo "memcheck_path_prefix_replacement[\"/var/user/git_repos/my_proj\"]=\"<my proj>\""
+			echo "memcheck_path_prefix_replacement[\"/var/user/git_repos/another_libs\"]=\"<another lib>\""
 		} >> "${config_file}"
     elif [ "${test_case}" == "with_substitution_backslash" ]; then
 		{
-			echo "memcheck_path_prefix_replacement[\"/var/user/git_repos/computation_libs\"]=\"[deps \\\\ computation]\"" 
-			echo "memcheck_path_prefix_replacement[\"/var/user/git_repos/my_proj\"]=\"[my proj]\"" 
-			echo "memcheck_path_prefix_replacement[\"/var/user/git_repos/another_libs\"]=\"[deps \\\\ another lib]\"" 
+			echo "memcheck_path_prefix_replacement[\"/var/user/git_repos/computation_libs\"]=\"[deps \\\\ computation]\""
+			echo "memcheck_path_prefix_replacement[\"/var/user/git_repos/my_proj\"]=\"[my proj]\""
+			echo "memcheck_path_prefix_replacement[\"/var/user/git_repos/another_libs\"]=\"[deps \\\\ another lib]\""
 		} >> "${config_file}"
     elif [ "${test_case}" == "with_substitution_backquote" ]; then
 		{
 			echo "memcheck_path_prefix_replacement[\"/var/user/git_repos/computation_libs\"]=\"\\\`computation libs\\\`\""
-			echo "memcheck_path_prefix_replacement[\"/var/user/git_repos/my_proj\"]=\"\\\`my proj\\\`\"" 
+			echo "memcheck_path_prefix_replacement[\"/var/user/git_repos/my_proj\"]=\"\\\`my proj\\\`\""
 			echo "memcheck_path_prefix_replacement[\"/var/user/git_repos/another_libs\"]=\"\\\`another lib\\\`\""
 		} >> "${config_file}"
     else
 		{
-			echo "memcheck_path_prefix_replacement[\"/var/user/git_repos/computation_libs/\"]=\"\"" 
-			echo "memcheck_path_prefix_replacement[\"/var/user/git_repos/my_proj/\"]=\"\"" 
+			echo "memcheck_path_prefix_replacement[\"/var/user/git_repos/computation_libs/\"]=\"\""
+			echo "memcheck_path_prefix_replacement[\"/var/user/git_repos/my_proj/\"]=\"\""
 			echo "memcheck_path_prefix_replacement[\"/var/user/git_repos/another_libs/\"]=\"\""
 		} >> "${config_file}"
     fi
@@ -96,6 +96,8 @@ function test_path_prefix_substitution()
 
     # Compare report output with reference reports
     expect_content_to_match "${test_ref_report_dir}" "${report_out_dir}"
+
+    expect_empty_file "${test_err_output}"
 
     expect_exit_code $test_exit_code 0
 }

--- a/tests/generate_html_outputs_ts/path_url_link_generation_ts_ptc.sh
+++ b/tests/generate_html_outputs_ts/path_url_link_generation_ts_ptc.sh
@@ -1,0 +1,140 @@
+#! /usr/bin/env bash
+
+test_parameter=$1
+
+resolved_script_path=$(readlink -f "$0")
+current_script_dir=$(dirname "${resolved_script_path}")
+current_full_path=$(readlink -e "${current_script_dir}")
+
+test_utils_import=$(readlink -e "${current_full_path}/../utils.test.sh")
+source "${test_utils_import}"
+
+# List cases
+test_cases=(
+    "no_types"
+    "unknown_types"
+    "lower_case_types"
+    "snake_case_types"
+    "mixed_case_types"
+)
+
+list_test_cases_option "$1"
+
+############
+### TEST ###
+############
+
+function setup_test()
+{
+    local test_case=$1
+    local test_out_dir=$(get_test_outdir)
+    local generate_html_report="$(get_tools_bin_dir)/generate_html_report.sh"
+
+    # Create output dir if needed
+    local test_case_out_dir="${test_out_dir}${test_case}/"
+    [ ! -d "${test_case_out_dir}" ] && mkdir -p "${test_case_out_dir}"
+
+    # Create config files
+    local useless_result=$(cd "${test_case_out_dir}" && "${generate_html_report}" -g)
+    local config_file="${test_case_out_dir}memcheck-cover.config"
+    expect_file "${config_file}"
+
+    {
+        if [ "${test_case}" == "no_types" ] || [ "${test_case}" == "unknown_types" ]; then
+            echo "memcheck_url_prefix_replacement[\"/var/user/git_repos/computation_libs/\"]=\"whatever\""
+            echo "memcheck_url_prefix_replacement[\"/var/user/git_repos/my_proj/\"]=\"whatever\""
+            echo "memcheck_url_prefix_replacement[\"/var/user/git_repos/another_libs/\"]=\"whatever\""
+
+            if [ "${test_case}" == "no_types" ]; then
+                echo "memcheck_url_prefix_replacement_type[\"/var/user/git_repos/computation_libs/\"]=\"\""
+                echo "memcheck_url_prefix_replacement_type[\"/var/user/git_repos/my_proj/\"]=\"\""
+                echo "memcheck_url_prefix_replacement_type[\"/var/user/git_repos/another_libs/\"]=\"\""
+            else
+                echo "memcheck_url_prefix_replacement_type[\"/var/user/git_repos/computation_libs/\"]=\"unknown\""
+                echo "memcheck_url_prefix_replacement_type[\"/var/user/git_repos/my_proj/\"]=\"unknown\""
+                echo "memcheck_url_prefix_replacement_type[\"/var/user/git_repos/another_libs/\"]=\"unknown\""
+            fi
+        else
+            echo "memcheck_url_prefix_replacement[\"/var/user/git_repos/computation_libs/\"]=\"http://mygithub.io/example/example_project/blob/master/\""
+            echo "memcheck_url_prefix_replacement[\"/var/user/git_repos/my_proj/\"]=\"http://mygitlab.io/example/example_project/-/blob/master/\""
+            echo "memcheck_url_prefix_replacement[\"/var/user/git_repos/another_libs/\"]=\"http://mybitbucket.io/example/example_project/src/master/\""
+
+            if [ "${test_case}" == "lower_case_types" ]; then
+                echo "memcheck_url_prefix_replacement_type[\"/var/user/git_repos/computation_libs/\"]=\"github\""
+                echo "memcheck_url_prefix_replacement_type[\"/var/user/git_repos/my_proj/\"]=\"gitlab\""
+                echo "memcheck_url_prefix_replacement_type[\"/var/user/git_repos/another_libs/\"]=\"bitbucket\""
+            elif [ "${test_case}" == "snake_case_types" ]; then
+                echo "memcheck_url_prefix_replacement_type[\"/var/user/git_repos/computation_libs/\"]=\"GitHub\""
+                echo "memcheck_url_prefix_replacement_type[\"/var/user/git_repos/my_proj/\"]=\"GitLab\""
+                echo "memcheck_url_prefix_replacement_type[\"/var/user/git_repos/another_libs/\"]=\"BitBucket\""
+            else
+                echo "memcheck_url_prefix_replacement_type[\"/var/user/git_repos/computation_libs/\"]=\"GITHUB\""
+                echo "memcheck_url_prefix_replacement_type[\"/var/user/git_repos/my_proj/\"]=\"gitLAB\""
+                echo "memcheck_url_prefix_replacement_type[\"/var/user/git_repos/another_libs/\"]=\"BITbucket\""
+            fi
+        fi
+    } >> "${config_file}"
+
+    # Copy memcheck report if not already done
+    local test_resx_dir=$(get_test_resources_dir)
+    cp "${test_resx_dir}fake_multiple_path_report.memcheck" "${test_case_out_dir}"
+}
+
+function test_path_url_link_generation()
+{
+    local test_case=$1
+    local test_out_dir=$(get_test_outdir)
+    local generate_html_report="$(get_tools_bin_dir)/generate_html_report.sh"
+
+    local test_case_out_dir="${test_out_dir}${test_case}/"
+    local test_std_output="${test_case_out_dir}test.out"
+    local test_err_output="${test_case_out_dir}test.err.out"
+
+    local test_ref_report_dir="${current_full_path}/ref/path_url_link_generation_report/"
+    local report_out_dir="${test_case_out_dir}report/"
+
+    local config_file="${test_case_out_dir}memcheck-cover.config"
+
+    # Call the html report generator with the ${test_case_out_dir} as input directory
+    # and the ${report_out_dir} as output directory
+    "${generate_html_report}" -i "${test_case_out_dir}" -o "${report_out_dir}" -c "${config_file}" > "${test_std_output}" 2> "${test_err_output}"
+    local test_exit_code=$?
+
+    ### Check test output
+
+    if [ "${test_case}" == "no_types" ] || [ "${test_case}" == "unknown_types" ]; then
+
+        if [ "${test_case}" == "no_types" ]; then
+            expect_output "${test_err_output}" "Error: 'memcheck_url_prefix_replacement_type' not set for key '/var/user/git_repos/computation_libs/'"
+            expect_output "${test_err_output}" "Error: 'memcheck_url_prefix_replacement_type' not set for key '/var/user/git_repos/another_libs/'"
+            expect_output "${test_err_output}" "Error: 'memcheck_url_prefix_replacement_type' not set for key '/var/user/git_repos/my_proj/'"
+        else
+            expect_output "${test_err_output}" "Error: Invalid configuration value 'unknown' for parameter: memcheck_url_prefix_replacement_type['/var/user/git_repos/computation_libs/']"
+            expect_output "${test_err_output}" "Error: Invalid configuration value 'unknown' for parameter: memcheck_url_prefix_replacement_type['/var/user/git_repos/another_libs/']"
+            expect_output "${test_err_output}" "Error: Invalid configuration value 'unknown' for parameter: memcheck_url_prefix_replacement_type['/var/user/git_repos/my_proj/']"
+        fi
+
+        expect_exit_code $test_exit_code 1
+    else
+        # Expect HTML part files
+        expect_file "${report_out_dir}fake_multiple_path_report.memcheck.html.part.js"
+
+        # Compare report output with reference reports
+        expect_content_to_match "${test_ref_report_dir}" "${report_out_dir}"
+
+        expect_empty_file "${test_err_output}"
+
+        expect_exit_code $test_exit_code 0
+    fi
+}
+
+# Init global
+error_occured=0
+
+# Setup test
+setup_test "${test_parameter}"
+
+# Run test
+test_path_url_link_generation "${test_parameter}"
+
+exit $error_occured

--- a/tests/generate_html_outputs_ts/ref/combined_path_substitution_and_url_link_report/fake_multiple_path_report.memcheck.html.part.js
+++ b/tests/generate_html_outputs_ts/ref/combined_path_substitution_and_url_link_report/fake_multiple_path_report.memcheck.html.part.js
@@ -1,0 +1,51 @@
+async function updateContentOnceLoaded1()
+{
+    var data =`
+==1== Memcheck, a memory error detector<br />
+==1== Copyright (C), and GNU GPL'd, by Julian Seward et al.<br />
+==1== Using Valgrind and LibVEX; rerun with -h for copyright info<br />
+==1== Command: fake_bin_with_multiple_local_dir<br />
+==1== Parent PID: 1<br />
+==1==<br />
+==1== <span class="error_leak">Illegal memory pool address</span><br />
+==1== &nbsp; &nbsp;at 0x10101042: my_func() (<a class="leak_file_info" href="http://mygitlab.io/example/example_project/-/blob/master/src/main.cpp#L16">[my proj]/src/main.cpp:16</a>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<a class="leak_file_info" href="http://mygitlab.io/example/example_project/-/blob/master/src/main.cpp#L22">[my proj]/src/main.cpp:22</a>)<br />
+==1== <span class="leak_context_info">&nbsp;Address 0xabcdef1234 is on thread 1's stack</span><br />
+==1== &nbsp; &nbsp;in frame #0, created by my_func() (<a class="leak_file_info" href="http://mygitlab.io/example/example_project/-/blob/master/src/main.cpp#L9">[my proj]/src/main.cpp:9</a>)<br />
+==1==<br />
+==1== <span class="error_leak">Syscall param write(buf) points to uninitialised byte(s)</span><br />
+==1== &nbsp; &nbsp;at 0x10101042: write (<span class="leak_file_info">write.c:27</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call() (<a class="leak_file_info" href="http://mygithub.io/example/example_project/blob/master/src/Functionnality.cpp#L13">[deps / computation]/src/Functionnality.cpp:13</a>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall() (<a class="leak_file_info" href="http://mygitlab.io/example/example_project/-/blob/master/src/my_lib/ComputationWrapper.cpp#L21">[my proj]/src/my_lib/ComputationWrapper.cpp:21</a>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<a class="leak_file_info" href="http://mygitlab.io/example/example_project/-/blob/master/src/main.cpp#L22">[my proj]/src/main.cpp:22</a>)<br />
+==1== <span class="leak_context_info">&nbsp;Address 0xabcdef1234 is 0 bytes inside a block of size 4 alloc'd</span><br />
+==1== &nbsp; &nbsp;at 0x10101042: operator new(unsigned long) (in a_host_lib.so)<br />
+==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call() (<a class="leak_file_info" href="http://mygithub.io/example/example_project/blob/master/src/Functionnality.cpp#L10">[deps / computation]/src/Functionnality.cpp:10</a>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall() (<a class="leak_file_info" href="http://mygitlab.io/example/example_project/-/blob/master/src/my_lib/ComputationWrapper.cpp#L21">[my proj]/src/my_lib/ComputationWrapper.cpp:21</a>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<a class="leak_file_info" href="http://mygitlab.io/example/example_project/-/blob/master/src/main.cpp#L22">[my proj]/src/main.cpp:22</a>)<br />
+==1== <span class="leak_context_info">&nbsp;Uninitialised value was created by a heap allocation</span><br />
+==1== &nbsp; &nbsp;at 0x10101042: operator new(unsigned long) (in a_host_lib.so)<br />
+==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call() (<a class="leak_file_info" href="http://mygithub.io/example/example_project/blob/master/src/Functionnality.cpp#L10">[deps / computation]/src/Functionnality.cpp:10</a>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall() (<a class="leak_file_info" href="http://mygitlab.io/example/example_project/-/blob/master/src/my_lib/ComputationWrapper.cpp#L21">[my proj]/src/my_lib/ComputationWrapper.cpp:21</a>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<a class="leak_file_info" href="http://mygitlab.io/example/example_project/-/blob/master/src/main.cpp#L22">[my proj]/src/main.cpp:22</a>)<br />
+==1==<br />
+==1== <span class="warning_leak">Conditional jump or move depends on uninitialised value(s)</span><br />
+==1== &nbsp; &nbsp;at 0x10101042: another_lib::another_function_call() (<a class="leak_file_info" href="http://mybitbucket.io/example/example_project/src/master/src/AnotherFunctionnality.cpp#-14">[deps / another lib]/src/AnotherFunctionnality.cpp:14</a>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<a class="leak_file_info" href="http://mygitlab.io/example/example_project/-/blob/master/src/main.cpp#L34">[my proj]/src/main.cpp:34</a>)<br />
+==1== <span class="leak_context_info">&nbsp;Uninitialised value was created by a stack allocation</span><br />
+==1== &nbsp; &nbsp;at 0x10101042: another_lib::another_function_call() (<a class="leak_file_info" href="http://mybitbucket.io/example/example_project/src/master/src/AnotherFunctionnality.cpp#-5">[deps / another lib]/src/AnotherFunctionnality.cpp:5</a>)<br />
+==1==<br />
+==1==<br />
+==1== <span class="valgrind_summary_title">HEAP SUMMARY:</span><br />
+==1== &nbsp; &nbsp; in use at exit: 0 bytes in 0 blocks<br />
+==1== &nbsp; total heap usage: 5 allocs, 5 frees, 149,512 bytes allocated<br />
+==1==<br />
+==1== All heap blocks were freed -- no leaks are possible<br />
+==1==<br />
+==1== For counts of detected and suppressed errors, rerun with: -v<br />
+==1== <span class="valgrind_summary_title">ERROR SUMMARY:</span> 3 errors from 3 contexts (suppressed: 0 from 0)<br />
+`;
+    var analysis_div = document.getElementById('valgrind.result1.Report');
+    analysis_div.innerHTML=data;
+}
+updateContentOnceLoaded1();

--- a/tests/generate_html_outputs_ts/ref/combined_path_substitution_and_url_link_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/combined_path_substitution_and_url_link_report/index.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <link rel="stylesheet" type="text/css" href="memcheck-cover.css">
+        <script type="text/javascript" src="memcheck-cover.js"></script>
+        <title>Valgrind's memcheck report</title>
+
+        <!-- Valgrind reports asynchronous loading parts -->
+        <script src="fake_multiple_path_report.memcheck.html.part.js" async="async"></script>
+    </head>
+    <body>
+        <div class="report_container">
+            <div class="report_header">
+                <div class="report_title">
+                    Valgrind's memcheck report
+                </div>
+                <div class="report_separator"></div>
+            </div>
+            <div class="report_content">
+                <div class="report_summary">
+                    <div class="report_summary_title">Result summary:</div>
+                    <div class="report_summary_ratio" title="Errors: 1" style="background-image: linear-gradient(to right, var(--summary-status-pass-font-color) 0%, var(--summary-status-warning-font-color) 0%, var(--summary-status-warning-font-color) 0%, var(--summary-status-error-font-color) 0%, var(--summary-status-error-font-color) 100%);">
+                        Pass: 0 / 1
+                    </div>
+                    <div class="report_summary_errors">Errors: 2</div>
+                    <div class="report_summary_warnings">Warnings: 1</div>
+                    <div class="report_summary_infos">Infos: 4</div>
+                    <br /><br />
+                    <div title="Expand all" onclick="JavaScript: ExpandAll();" class="expandall"><div></div><div></div><div></div></div>
+                    <div title="Collapse all" onclick="JavaScript: CollapseAll();" class="collapseall"><div></div><div></div><div></div></div>
+                    <div class="multiple_choice_button_container"><span class="button_description_text">Title: </span><span class="analysis_title_command_part" onclick="JavaScript: SetAnalysisTitle('command');">Command</span><span class="analysis_title_name_part" onclick="JavaScript: SetAnalysisTitle('name');">Analysis name</span></div>
+                    <div class="multiple_choice_button_container"><span class="button_description_text">Theme: </span><span class="css_theme_light_part" onclick="JavaScript: SetCssTheme('light');">Light</span><span class="css_theme_dark_grey_part" onclick="JavaScript: SetCssTheme('dark-grey');">Dark-grey</span><span class="css_theme_dark_blue_part" onclick="JavaScript: SetCssTheme('dark-blue');">Dark-blue</span></div>
+                </div>
+                <div class="memcheck_analysis_title" onclick="JavaScript: ToggleAnalysisResultVisibility('valgrind.result1');">
+                    <span id="valgrind.result1.VisibilityIcon"><div class="expand"><div></div></div></span> <span class="brace_recenter">[</span><span class="analysis_error_status">ERROR</span><span class="brace_recenter">]</span> <span class="analysis_command_title">Command: fake_bin_with_multiple_local_dir</span><span class="analysis_name_title">Analysis name: fake_multiple_path_report</span> <span class="analysis_type_infos"><div class="report_summary_errors">Errors: 2</div>
+                    <div class="report_summary_warnings">Warnings: 1</div>
+                    <div class="report_summary_infos">Infos: 4</div></span>
+                </div>
+                <div id="valgrind.result1.Report" class="memcheck_analysis_content hidden">
+                    <span class="result_loader"></span><span class="result_loader_text"></span>
+                </div>
+            </div>
+            <div class="report_footer">
+                <div class="generation_tool_version">
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.1
+                </div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/tests/generate_html_outputs_ts/ref/combined_path_substitution_and_url_link_report/memcheck-cover.css
+++ b/tests/generate_html_outputs_ts/ref/combined_path_substitution_and_url_link_report/memcheck-cover.css
@@ -1,0 +1,1 @@
+../../../../bin/html_res/memcheck-cover.css

--- a/tests/generate_html_outputs_ts/ref/combined_path_substitution_and_url_link_report/memcheck-cover.js
+++ b/tests/generate_html_outputs_ts/ref/combined_path_substitution_and_url_link_report/memcheck-cover.js
@@ -1,0 +1,1 @@
+../../../../bin/html_res/memcheck-cover.js

--- a/tests/generate_html_outputs_ts/ref/path_prefix_substitution/deletion_report/fake_multiple_path_report.memcheck.html.part.js
+++ b/tests/generate_html_outputs_ts/ref/path_prefix_substitution/deletion_report/fake_multiple_path_report.memcheck.html.part.js
@@ -8,32 +8,32 @@ async function updateContentOnceLoaded1()
 ==1== Parent PID: 1<br />
 ==1==<br />
 ==1== <span class="error_leak">Illegal memory pool address</span><br />
-==1== &nbsp; &nbsp;at 0x10101042: my_func()  (<span class="leak_file_info">src/main.cpp:16</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: main  (<span class="leak_file_info">src/main.cpp:22</span>)<br />
+==1== &nbsp; &nbsp;at 0x10101042: my_func() (<span class="leak_file_info">src/main.cpp:16</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">src/main.cpp:22</span>)<br />
 ==1== <span class="leak_context_info">&nbsp;Address 0xabcdef1234 is on thread 1's stack</span><br />
-==1== &nbsp; &nbsp;in frame #0, created by my_func()  (<span class="leak_file_info">src/main.cpp:9</span>)<br />
+==1== &nbsp; &nbsp;in frame #0, created by my_func() (<span class="leak_file_info">src/main.cpp:9</span>)<br />
 ==1==<br />
 ==1== <span class="error_leak">Syscall param write(buf) points to uninitialised byte(s)</span><br />
 ==1== &nbsp; &nbsp;at 0x10101042: write (<span class="leak_file_info">write.c:27</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call()  (<span class="leak_file_info">src/Functionnality.cpp:13</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall()  (<span class="leak_file_info">src/my_lib/ComputationWrapper.cpp:21</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: main  (<span class="leak_file_info">src/main.cpp:22</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call() (<span class="leak_file_info">src/Functionnality.cpp:13</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall() (<span class="leak_file_info">src/my_lib/ComputationWrapper.cpp:21</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">src/main.cpp:22</span>)<br />
 ==1== <span class="leak_context_info">&nbsp;Address 0xabcdef1234 is 0 bytes inside a block of size 4 alloc'd</span><br />
 ==1== &nbsp; &nbsp;at 0x10101042: operator new(unsigned long) (in a_host_lib.so)<br />
-==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call()  (<span class="leak_file_info">src/Functionnality.cpp:10</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall()  (<span class="leak_file_info">src/my_lib/ComputationWrapper.cpp:21</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: main  (<span class="leak_file_info">src/main.cpp:22</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call() (<span class="leak_file_info">src/Functionnality.cpp:10</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall() (<span class="leak_file_info">src/my_lib/ComputationWrapper.cpp:21</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">src/main.cpp:22</span>)<br />
 ==1== <span class="leak_context_info">&nbsp;Uninitialised value was created by a heap allocation</span><br />
 ==1== &nbsp; &nbsp;at 0x10101042: operator new(unsigned long) (in a_host_lib.so)<br />
-==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call()  (<span class="leak_file_info">src/Functionnality.cpp:10</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall()  (<span class="leak_file_info">src/my_lib/ComputationWrapper.cpp:21</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: main  (<span class="leak_file_info">src/main.cpp:22</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call() (<span class="leak_file_info">src/Functionnality.cpp:10</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall() (<span class="leak_file_info">src/my_lib/ComputationWrapper.cpp:21</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">src/main.cpp:22</span>)<br />
 ==1==<br />
 ==1== <span class="warning_leak">Conditional jump or move depends on uninitialised value(s)</span><br />
-==1== &nbsp; &nbsp;at 0x10101042: another_lib::another_function_call()  (<span class="leak_file_info">src/AnotherFunctionnality.cpp:14</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: main  (<span class="leak_file_info">src/main.cpp:34</span>)<br />
+==1== &nbsp; &nbsp;at 0x10101042: another_lib::another_function_call() (<span class="leak_file_info">src/AnotherFunctionnality.cpp:14</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">src/main.cpp:34</span>)<br />
 ==1== <span class="leak_context_info">&nbsp;Uninitialised value was created by a stack allocation</span><br />
-==1== &nbsp; &nbsp;at 0x10101042: another_lib::another_function_call()  (<span class="leak_file_info">src/AnotherFunctionnality.cpp:5</span>)<br />
+==1== &nbsp; &nbsp;at 0x10101042: another_lib::another_function_call() (<span class="leak_file_info">src/AnotherFunctionnality.cpp:5</span>)<br />
 ==1==<br />
 ==1==<br />
 ==1== <span class="valgrind_summary_title">HEAP SUMMARY:</span><br />

--- a/tests/generate_html_outputs_ts/ref/path_prefix_substitution/with_substitution_backquote_report/fake_multiple_path_report.memcheck.html.part.js
+++ b/tests/generate_html_outputs_ts/ref/path_prefix_substitution/with_substitution_backquote_report/fake_multiple_path_report.memcheck.html.part.js
@@ -8,32 +8,32 @@ async function updateContentOnceLoaded1()
 ==1== Parent PID: 1<br />
 ==1==<br />
 ==1== <span class="error_leak">Illegal memory pool address</span><br />
-==1== &nbsp; &nbsp;at 0x10101042: my_func()  (<span class="leak_file_info">\`my proj\`/src/main.cpp:16</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: main  (<span class="leak_file_info">\`my proj\`/src/main.cpp:22</span>)<br />
+==1== &nbsp; &nbsp;at 0x10101042: my_func() (<span class="leak_file_info">\`my proj\`/src/main.cpp:16</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">\`my proj\`/src/main.cpp:22</span>)<br />
 ==1== <span class="leak_context_info">&nbsp;Address 0xabcdef1234 is on thread 1's stack</span><br />
-==1== &nbsp; &nbsp;in frame #0, created by my_func()  (<span class="leak_file_info">\`my proj\`/src/main.cpp:9</span>)<br />
+==1== &nbsp; &nbsp;in frame #0, created by my_func() (<span class="leak_file_info">\`my proj\`/src/main.cpp:9</span>)<br />
 ==1==<br />
 ==1== <span class="error_leak">Syscall param write(buf) points to uninitialised byte(s)</span><br />
 ==1== &nbsp; &nbsp;at 0x10101042: write (<span class="leak_file_info">write.c:27</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call()  (<span class="leak_file_info">\`computation libs\`/src/Functionnality.cpp:13</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall()  (<span class="leak_file_info">\`my proj\`/src/my_lib/ComputationWrapper.cpp:21</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: main  (<span class="leak_file_info">\`my proj\`/src/main.cpp:22</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call() (<span class="leak_file_info">\`computation libs\`/src/Functionnality.cpp:13</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall() (<span class="leak_file_info">\`my proj\`/src/my_lib/ComputationWrapper.cpp:21</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">\`my proj\`/src/main.cpp:22</span>)<br />
 ==1== <span class="leak_context_info">&nbsp;Address 0xabcdef1234 is 0 bytes inside a block of size 4 alloc'd</span><br />
 ==1== &nbsp; &nbsp;at 0x10101042: operator new(unsigned long) (in a_host_lib.so)<br />
-==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call()  (<span class="leak_file_info">\`computation libs\`/src/Functionnality.cpp:10</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall()  (<span class="leak_file_info">\`my proj\`/src/my_lib/ComputationWrapper.cpp:21</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: main  (<span class="leak_file_info">\`my proj\`/src/main.cpp:22</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call() (<span class="leak_file_info">\`computation libs\`/src/Functionnality.cpp:10</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall() (<span class="leak_file_info">\`my proj\`/src/my_lib/ComputationWrapper.cpp:21</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">\`my proj\`/src/main.cpp:22</span>)<br />
 ==1== <span class="leak_context_info">&nbsp;Uninitialised value was created by a heap allocation</span><br />
 ==1== &nbsp; &nbsp;at 0x10101042: operator new(unsigned long) (in a_host_lib.so)<br />
-==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call()  (<span class="leak_file_info">\`computation libs\`/src/Functionnality.cpp:10</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall()  (<span class="leak_file_info">\`my proj\`/src/my_lib/ComputationWrapper.cpp:21</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: main  (<span class="leak_file_info">\`my proj\`/src/main.cpp:22</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call() (<span class="leak_file_info">\`computation libs\`/src/Functionnality.cpp:10</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall() (<span class="leak_file_info">\`my proj\`/src/my_lib/ComputationWrapper.cpp:21</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">\`my proj\`/src/main.cpp:22</span>)<br />
 ==1==<br />
 ==1== <span class="warning_leak">Conditional jump or move depends on uninitialised value(s)</span><br />
-==1== &nbsp; &nbsp;at 0x10101042: another_lib::another_function_call()  (<span class="leak_file_info">\`another lib\`/src/AnotherFunctionnality.cpp:14</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: main  (<span class="leak_file_info">\`my proj\`/src/main.cpp:34</span>)<br />
+==1== &nbsp; &nbsp;at 0x10101042: another_lib::another_function_call() (<span class="leak_file_info">\`another lib\`/src/AnotherFunctionnality.cpp:14</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">\`my proj\`/src/main.cpp:34</span>)<br />
 ==1== <span class="leak_context_info">&nbsp;Uninitialised value was created by a stack allocation</span><br />
-==1== &nbsp; &nbsp;at 0x10101042: another_lib::another_function_call()  (<span class="leak_file_info">\`another lib\`/src/AnotherFunctionnality.cpp:5</span>)<br />
+==1== &nbsp; &nbsp;at 0x10101042: another_lib::another_function_call() (<span class="leak_file_info">\`another lib\`/src/AnotherFunctionnality.cpp:5</span>)<br />
 ==1==<br />
 ==1==<br />
 ==1== <span class="valgrind_summary_title">HEAP SUMMARY:</span><br />

--- a/tests/generate_html_outputs_ts/ref/path_prefix_substitution/with_substitution_backslash_report/fake_multiple_path_report.memcheck.html.part.js
+++ b/tests/generate_html_outputs_ts/ref/path_prefix_substitution/with_substitution_backslash_report/fake_multiple_path_report.memcheck.html.part.js
@@ -8,32 +8,32 @@ async function updateContentOnceLoaded1()
 ==1== Parent PID: 1<br />
 ==1==<br />
 ==1== <span class="error_leak">Illegal memory pool address</span><br />
-==1== &nbsp; &nbsp;at 0x10101042: my_func()  (<span class="leak_file_info">[my proj]/src/main.cpp:16</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: main  (<span class="leak_file_info">[my proj]/src/main.cpp:22</span>)<br />
+==1== &nbsp; &nbsp;at 0x10101042: my_func() (<span class="leak_file_info">[my proj]/src/main.cpp:16</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">[my proj]/src/main.cpp:22</span>)<br />
 ==1== <span class="leak_context_info">&nbsp;Address 0xabcdef1234 is on thread 1's stack</span><br />
-==1== &nbsp; &nbsp;in frame #0, created by my_func()  (<span class="leak_file_info">[my proj]/src/main.cpp:9</span>)<br />
+==1== &nbsp; &nbsp;in frame #0, created by my_func() (<span class="leak_file_info">[my proj]/src/main.cpp:9</span>)<br />
 ==1==<br />
 ==1== <span class="error_leak">Syscall param write(buf) points to uninitialised byte(s)</span><br />
 ==1== &nbsp; &nbsp;at 0x10101042: write (<span class="leak_file_info">write.c:27</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call()  (<span class="leak_file_info">[deps \\ computation]/src/Functionnality.cpp:13</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall()  (<span class="leak_file_info">[my proj]/src/my_lib/ComputationWrapper.cpp:21</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: main  (<span class="leak_file_info">[my proj]/src/main.cpp:22</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call() (<span class="leak_file_info">[deps \\ computation]/src/Functionnality.cpp:13</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall() (<span class="leak_file_info">[my proj]/src/my_lib/ComputationWrapper.cpp:21</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">[my proj]/src/main.cpp:22</span>)<br />
 ==1== <span class="leak_context_info">&nbsp;Address 0xabcdef1234 is 0 bytes inside a block of size 4 alloc'd</span><br />
 ==1== &nbsp; &nbsp;at 0x10101042: operator new(unsigned long) (in a_host_lib.so)<br />
-==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call()  (<span class="leak_file_info">[deps \\ computation]/src/Functionnality.cpp:10</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall()  (<span class="leak_file_info">[my proj]/src/my_lib/ComputationWrapper.cpp:21</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: main  (<span class="leak_file_info">[my proj]/src/main.cpp:22</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call() (<span class="leak_file_info">[deps \\ computation]/src/Functionnality.cpp:10</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall() (<span class="leak_file_info">[my proj]/src/my_lib/ComputationWrapper.cpp:21</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">[my proj]/src/main.cpp:22</span>)<br />
 ==1== <span class="leak_context_info">&nbsp;Uninitialised value was created by a heap allocation</span><br />
 ==1== &nbsp; &nbsp;at 0x10101042: operator new(unsigned long) (in a_host_lib.so)<br />
-==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call()  (<span class="leak_file_info">[deps \\ computation]/src/Functionnality.cpp:10</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall()  (<span class="leak_file_info">[my proj]/src/my_lib/ComputationWrapper.cpp:21</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: main  (<span class="leak_file_info">[my proj]/src/main.cpp:22</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call() (<span class="leak_file_info">[deps \\ computation]/src/Functionnality.cpp:10</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall() (<span class="leak_file_info">[my proj]/src/my_lib/ComputationWrapper.cpp:21</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">[my proj]/src/main.cpp:22</span>)<br />
 ==1==<br />
 ==1== <span class="warning_leak">Conditional jump or move depends on uninitialised value(s)</span><br />
-==1== &nbsp; &nbsp;at 0x10101042: another_lib::another_function_call()  (<span class="leak_file_info">[deps \\ another lib]/src/AnotherFunctionnality.cpp:14</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: main  (<span class="leak_file_info">[my proj]/src/main.cpp:34</span>)<br />
+==1== &nbsp; &nbsp;at 0x10101042: another_lib::another_function_call() (<span class="leak_file_info">[deps \\ another lib]/src/AnotherFunctionnality.cpp:14</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">[my proj]/src/main.cpp:34</span>)<br />
 ==1== <span class="leak_context_info">&nbsp;Uninitialised value was created by a stack allocation</span><br />
-==1== &nbsp; &nbsp;at 0x10101042: another_lib::another_function_call()  (<span class="leak_file_info">[deps \\ another lib]/src/AnotherFunctionnality.cpp:5</span>)<br />
+==1== &nbsp; &nbsp;at 0x10101042: another_lib::another_function_call() (<span class="leak_file_info">[deps \\ another lib]/src/AnotherFunctionnality.cpp:5</span>)<br />
 ==1==<br />
 ==1==<br />
 ==1== <span class="valgrind_summary_title">HEAP SUMMARY:</span><br />

--- a/tests/generate_html_outputs_ts/ref/path_prefix_substitution/with_substitution_lt_and_gt_report/fake_multiple_path_report.memcheck.html.part.js
+++ b/tests/generate_html_outputs_ts/ref/path_prefix_substitution/with_substitution_lt_and_gt_report/fake_multiple_path_report.memcheck.html.part.js
@@ -8,32 +8,32 @@ async function updateContentOnceLoaded1()
 ==1== Parent PID: 1<br />
 ==1==<br />
 ==1== <span class="error_leak">Illegal memory pool address</span><br />
-==1== &nbsp; &nbsp;at 0x10101042: my_func()  (<span class="leak_file_info">&lt;my proj&gt;/src/main.cpp:16</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: main  (<span class="leak_file_info">&lt;my proj&gt;/src/main.cpp:22</span>)<br />
+==1== &nbsp; &nbsp;at 0x10101042: my_func() (<span class="leak_file_info">&lt;my proj&gt;/src/main.cpp:16</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">&lt;my proj&gt;/src/main.cpp:22</span>)<br />
 ==1== <span class="leak_context_info">&nbsp;Address 0xabcdef1234 is on thread 1's stack</span><br />
-==1== &nbsp; &nbsp;in frame #0, created by my_func()  (<span class="leak_file_info">&lt;my proj&gt;/src/main.cpp:9</span>)<br />
+==1== &nbsp; &nbsp;in frame #0, created by my_func() (<span class="leak_file_info">&lt;my proj&gt;/src/main.cpp:9</span>)<br />
 ==1==<br />
 ==1== <span class="error_leak">Syscall param write(buf) points to uninitialised byte(s)</span><br />
 ==1== &nbsp; &nbsp;at 0x10101042: write (<span class="leak_file_info">write.c:27</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call()  (<span class="leak_file_info">&lt;computation libs&gt;/src/Functionnality.cpp:13</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall()  (<span class="leak_file_info">&lt;my proj&gt;/src/my_lib/ComputationWrapper.cpp:21</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: main  (<span class="leak_file_info">&lt;my proj&gt;/src/main.cpp:22</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call() (<span class="leak_file_info">&lt;computation libs&gt;/src/Functionnality.cpp:13</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall() (<span class="leak_file_info">&lt;my proj&gt;/src/my_lib/ComputationWrapper.cpp:21</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">&lt;my proj&gt;/src/main.cpp:22</span>)<br />
 ==1== <span class="leak_context_info">&nbsp;Address 0xabcdef1234 is 0 bytes inside a block of size 4 alloc'd</span><br />
 ==1== &nbsp; &nbsp;at 0x10101042: operator new(unsigned long) (in a_host_lib.so)<br />
-==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call()  (<span class="leak_file_info">&lt;computation libs&gt;/src/Functionnality.cpp:10</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall()  (<span class="leak_file_info">&lt;my proj&gt;/src/my_lib/ComputationWrapper.cpp:21</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: main  (<span class="leak_file_info">&lt;my proj&gt;/src/main.cpp:22</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call() (<span class="leak_file_info">&lt;computation libs&gt;/src/Functionnality.cpp:10</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall() (<span class="leak_file_info">&lt;my proj&gt;/src/my_lib/ComputationWrapper.cpp:21</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">&lt;my proj&gt;/src/main.cpp:22</span>)<br />
 ==1== <span class="leak_context_info">&nbsp;Uninitialised value was created by a heap allocation</span><br />
 ==1== &nbsp; &nbsp;at 0x10101042: operator new(unsigned long) (in a_host_lib.so)<br />
-==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call()  (<span class="leak_file_info">&lt;computation libs&gt;/src/Functionnality.cpp:10</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall()  (<span class="leak_file_info">&lt;my proj&gt;/src/my_lib/ComputationWrapper.cpp:21</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: main  (<span class="leak_file_info">&lt;my proj&gt;/src/main.cpp:22</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call() (<span class="leak_file_info">&lt;computation libs&gt;/src/Functionnality.cpp:10</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall() (<span class="leak_file_info">&lt;my proj&gt;/src/my_lib/ComputationWrapper.cpp:21</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">&lt;my proj&gt;/src/main.cpp:22</span>)<br />
 ==1==<br />
 ==1== <span class="warning_leak">Conditional jump or move depends on uninitialised value(s)</span><br />
-==1== &nbsp; &nbsp;at 0x10101042: another_lib::another_function_call()  (<span class="leak_file_info">&lt;another lib&gt;/src/AnotherFunctionnality.cpp:14</span>)<br />
-==1== &nbsp; &nbsp;by 0x10101042: main  (<span class="leak_file_info">&lt;my proj&gt;/src/main.cpp:34</span>)<br />
+==1== &nbsp; &nbsp;at 0x10101042: another_lib::another_function_call() (<span class="leak_file_info">&lt;another lib&gt;/src/AnotherFunctionnality.cpp:14</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<span class="leak_file_info">&lt;my proj&gt;/src/main.cpp:34</span>)<br />
 ==1== <span class="leak_context_info">&nbsp;Uninitialised value was created by a stack allocation</span><br />
-==1== &nbsp; &nbsp;at 0x10101042: another_lib::another_function_call()  (<span class="leak_file_info">&lt;another lib&gt;/src/AnotherFunctionnality.cpp:5</span>)<br />
+==1== &nbsp; &nbsp;at 0x10101042: another_lib::another_function_call() (<span class="leak_file_info">&lt;another lib&gt;/src/AnotherFunctionnality.cpp:5</span>)<br />
 ==1==<br />
 ==1==<br />
 ==1== <span class="valgrind_summary_title">HEAP SUMMARY:</span><br />

--- a/tests/generate_html_outputs_ts/ref/path_url_link_generation_report/fake_multiple_path_report.memcheck.html.part.js
+++ b/tests/generate_html_outputs_ts/ref/path_url_link_generation_report/fake_multiple_path_report.memcheck.html.part.js
@@ -1,0 +1,51 @@
+async function updateContentOnceLoaded1()
+{
+    var data =`
+==1== Memcheck, a memory error detector<br />
+==1== Copyright (C), and GNU GPL'd, by Julian Seward et al.<br />
+==1== Using Valgrind and LibVEX; rerun with -h for copyright info<br />
+==1== Command: fake_bin_with_multiple_local_dir<br />
+==1== Parent PID: 1<br />
+==1==<br />
+==1== <span class="error_leak">Illegal memory pool address</span><br />
+==1== &nbsp; &nbsp;at 0x10101042: my_func() (<a class="leak_file_info" href="http://mygitlab.io/example/example_project/-/blob/master/src/main.cpp#L16">/var/user/git_repos/my_proj/src/main.cpp:16</a>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<a class="leak_file_info" href="http://mygitlab.io/example/example_project/-/blob/master/src/main.cpp#L22">/var/user/git_repos/my_proj/src/main.cpp:22</a>)<br />
+==1== <span class="leak_context_info">&nbsp;Address 0xabcdef1234 is on thread 1's stack</span><br />
+==1== &nbsp; &nbsp;in frame #0, created by my_func() (<a class="leak_file_info" href="http://mygitlab.io/example/example_project/-/blob/master/src/main.cpp#L9">/var/user/git_repos/my_proj/src/main.cpp:9</a>)<br />
+==1==<br />
+==1== <span class="error_leak">Syscall param write(buf) points to uninitialised byte(s)</span><br />
+==1== &nbsp; &nbsp;at 0x10101042: write (<span class="leak_file_info">write.c:27</span>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call() (<a class="leak_file_info" href="http://mygithub.io/example/example_project/blob/master/src/Functionnality.cpp#L13">/var/user/git_repos/computation_libs/src/Functionnality.cpp:13</a>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall() (<a class="leak_file_info" href="http://mygitlab.io/example/example_project/-/blob/master/src/my_lib/ComputationWrapper.cpp#L21">/var/user/git_repos/my_proj/src/my_lib/ComputationWrapper.cpp:21</a>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<a class="leak_file_info" href="http://mygitlab.io/example/example_project/-/blob/master/src/main.cpp#L22">/var/user/git_repos/my_proj/src/main.cpp:22</a>)<br />
+==1== <span class="leak_context_info">&nbsp;Address 0xabcdef1234 is 0 bytes inside a block of size 4 alloc'd</span><br />
+==1== &nbsp; &nbsp;at 0x10101042: operator new(unsigned long) (in a_host_lib.so)<br />
+==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call() (<a class="leak_file_info" href="http://mygithub.io/example/example_project/blob/master/src/Functionnality.cpp#L10">/var/user/git_repos/computation_libs/src/Functionnality.cpp:10</a>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall() (<a class="leak_file_info" href="http://mygitlab.io/example/example_project/-/blob/master/src/my_lib/ComputationWrapper.cpp#L21">/var/user/git_repos/my_proj/src/my_lib/ComputationWrapper.cpp:21</a>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<a class="leak_file_info" href="http://mygitlab.io/example/example_project/-/blob/master/src/main.cpp#L22">/var/user/git_repos/my_proj/src/main.cpp:22</a>)<br />
+==1== <span class="leak_context_info">&nbsp;Uninitialised value was created by a heap allocation</span><br />
+==1== &nbsp; &nbsp;at 0x10101042: operator new(unsigned long) (in a_host_lib.so)<br />
+==1== &nbsp; &nbsp;by 0x10101042: a_lib::function_call() (<a class="leak_file_info" href="http://mygithub.io/example/example_project/blob/master/src/Functionnality.cpp#L10">/var/user/git_repos/computation_libs/src/Functionnality.cpp:10</a>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: MyLib::FunctionCall() (<a class="leak_file_info" href="http://mygitlab.io/example/example_project/-/blob/master/src/my_lib/ComputationWrapper.cpp#L21">/var/user/git_repos/my_proj/src/my_lib/ComputationWrapper.cpp:21</a>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<a class="leak_file_info" href="http://mygitlab.io/example/example_project/-/blob/master/src/main.cpp#L22">/var/user/git_repos/my_proj/src/main.cpp:22</a>)<br />
+==1==<br />
+==1== <span class="warning_leak">Conditional jump or move depends on uninitialised value(s)</span><br />
+==1== &nbsp; &nbsp;at 0x10101042: another_lib::another_function_call() (<a class="leak_file_info" href="http://mybitbucket.io/example/example_project/src/master/src/AnotherFunctionnality.cpp#-14">/var/user/git_repos/another_libs/src/AnotherFunctionnality.cpp:14</a>)<br />
+==1== &nbsp; &nbsp;by 0x10101042: main (<a class="leak_file_info" href="http://mygitlab.io/example/example_project/-/blob/master/src/main.cpp#L34">/var/user/git_repos/my_proj/src/main.cpp:34</a>)<br />
+==1== <span class="leak_context_info">&nbsp;Uninitialised value was created by a stack allocation</span><br />
+==1== &nbsp; &nbsp;at 0x10101042: another_lib::another_function_call() (<a class="leak_file_info" href="http://mybitbucket.io/example/example_project/src/master/src/AnotherFunctionnality.cpp#-5">/var/user/git_repos/another_libs/src/AnotherFunctionnality.cpp:5</a>)<br />
+==1==<br />
+==1==<br />
+==1== <span class="valgrind_summary_title">HEAP SUMMARY:</span><br />
+==1== &nbsp; &nbsp; in use at exit: 0 bytes in 0 blocks<br />
+==1== &nbsp; total heap usage: 5 allocs, 5 frees, 149,512 bytes allocated<br />
+==1==<br />
+==1== All heap blocks were freed -- no leaks are possible<br />
+==1==<br />
+==1== For counts of detected and suppressed errors, rerun with: -v<br />
+==1== <span class="valgrind_summary_title">ERROR SUMMARY:</span> 3 errors from 3 contexts (suppressed: 0 from 0)<br />
+`;
+    var analysis_div = document.getElementById('valgrind.result1.Report');
+    analysis_div.innerHTML=data;
+}
+updateContentOnceLoaded1();

--- a/tests/generate_html_outputs_ts/ref/path_url_link_generation_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/path_url_link_generation_report/index.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <link rel="stylesheet" type="text/css" href="memcheck-cover.css">
+        <script type="text/javascript" src="memcheck-cover.js"></script>
+        <title>Valgrind's memcheck report</title>
+
+        <!-- Valgrind reports asynchronous loading parts -->
+        <script src="fake_multiple_path_report.memcheck.html.part.js" async="async"></script>
+    </head>
+    <body>
+        <div class="report_container">
+            <div class="report_header">
+                <div class="report_title">
+                    Valgrind's memcheck report
+                </div>
+                <div class="report_separator"></div>
+            </div>
+            <div class="report_content">
+                <div class="report_summary">
+                    <div class="report_summary_title">Result summary:</div>
+                    <div class="report_summary_ratio" title="Errors: 1" style="background-image: linear-gradient(to right, var(--summary-status-pass-font-color) 0%, var(--summary-status-warning-font-color) 0%, var(--summary-status-warning-font-color) 0%, var(--summary-status-error-font-color) 0%, var(--summary-status-error-font-color) 100%);">
+                        Pass: 0 / 1
+                    </div>
+                    <div class="report_summary_errors">Errors: 2</div>
+                    <div class="report_summary_warnings">Warnings: 1</div>
+                    <div class="report_summary_infos">Infos: 4</div>
+                    <br /><br />
+                    <div title="Expand all" onclick="JavaScript: ExpandAll();" class="expandall"><div></div><div></div><div></div></div>
+                    <div title="Collapse all" onclick="JavaScript: CollapseAll();" class="collapseall"><div></div><div></div><div></div></div>
+                    <div class="multiple_choice_button_container"><span class="button_description_text">Title: </span><span class="analysis_title_command_part" onclick="JavaScript: SetAnalysisTitle('command');">Command</span><span class="analysis_title_name_part" onclick="JavaScript: SetAnalysisTitle('name');">Analysis name</span></div>
+                    <div class="multiple_choice_button_container"><span class="button_description_text">Theme: </span><span class="css_theme_light_part" onclick="JavaScript: SetCssTheme('light');">Light</span><span class="css_theme_dark_grey_part" onclick="JavaScript: SetCssTheme('dark-grey');">Dark-grey</span><span class="css_theme_dark_blue_part" onclick="JavaScript: SetCssTheme('dark-blue');">Dark-blue</span></div>
+                </div>
+                <div class="memcheck_analysis_title" onclick="JavaScript: ToggleAnalysisResultVisibility('valgrind.result1');">
+                    <span id="valgrind.result1.VisibilityIcon"><div class="expand"><div></div></div></span> <span class="brace_recenter">[</span><span class="analysis_error_status">ERROR</span><span class="brace_recenter">]</span> <span class="analysis_command_title">Command: fake_bin_with_multiple_local_dir</span><span class="analysis_name_title">Analysis name: fake_multiple_path_report</span> <span class="analysis_type_infos"><div class="report_summary_errors">Errors: 2</div>
+                    <div class="report_summary_warnings">Warnings: 1</div>
+                    <div class="report_summary_infos">Infos: 4</div></span>
+                </div>
+                <div id="valgrind.result1.Report" class="memcheck_analysis_content hidden">
+                    <span class="result_loader"></span><span class="result_loader_text"></span>
+                </div>
+            </div>
+            <div class="report_footer">
+                <div class="generation_tool_version">
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.1
+                </div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/tests/generate_html_outputs_ts/ref/path_url_link_generation_report/memcheck-cover.css
+++ b/tests/generate_html_outputs_ts/ref/path_url_link_generation_report/memcheck-cover.css
@@ -1,0 +1,1 @@
+../../../../bin/html_res/memcheck-cover.css

--- a/tests/generate_html_outputs_ts/ref/path_url_link_generation_report/memcheck-cover.js
+++ b/tests/generate_html_outputs_ts/ref/path_url_link_generation_report/memcheck-cover.js
@@ -1,0 +1,1 @@
+../../../../bin/html_res/memcheck-cover.js

--- a/tests/generate_html_outputs_ts/ts_setup.sh
+++ b/tests/generate_html_outputs_ts/ts_setup.sh
@@ -94,7 +94,9 @@ function generate_many_result_report_ref_report()
         # Skip generated context reports
         if [[ "${ref_path}" == *"many_result_report" ]] \
 		   || [[ "${ref_path}" == *"violation_context_report" ]] \
-		   || [[ "${ref_path}" == *"path_prefix_substitution" ]]; then
+		   || [[ "${ref_path}" == *"path_prefix_substitution" ]] \
+		   || [[ "${ref_path}" == *"path_url_link_generation_report" ]] \
+		   || [[ "${ref_path}" == *"combined_path_substitution_and_url_link_report" ]]; then
             continue
         fi
 

--- a/tests/generate_html_params_ts/generate_config_param_ts_ptc.sh
+++ b/tests/generate_html_params_ts/generate_config_param_ts_ptc.sh
@@ -52,7 +52,7 @@ function test_generate_config_param()
     # Expect config file
     local output_config_file="${test_out_dir}memcheck-cover.config"
     # Expect information header
-    expect_content_to_match "${output_config_file}" "${current_full_path}/ref/default-memcheck-cover.config"
+    expect_content_to_match "${current_full_path}/ref/default-memcheck-cover.config" "${output_config_file}"
 
     expect_empty_file "${test_err_output}"
 

--- a/tests/generate_html_params_ts/ref/default-memcheck-cover.config
+++ b/tests/generate_html_params_ts/ref/default-memcheck-cover.config
@@ -123,6 +123,7 @@ memcheck_summary_criticality['still_reachable']="error"
 #===  Advanced options   ===
 #===========================
 
+###
 # Prefix replacement can be applied to remove or replace paths prefixes
 # It can be defined by filling the following map:
 #    memcheck_path_prefix_replacement["<prefix_to_replace>"]="<replacement_value>"
@@ -135,6 +136,38 @@ memcheck_summary_criticality['still_reachable']="error"
 #    ==1==    at 0x10101042: myFunc() (/var/user/repo/src/lib1/MyClass.cpp:14)
 # To:
 #    ==1==    at 0x10101042: myFunc() (<repo>/src/lib1/MyClass.cpp:14)
+#
+# Multiple replacements can be defined
+
+
+###
+# Source control server links can be added based on paths prefixes
+# It can be defined by filling the following map:
+#    memcheck_url_prefix_replacement["<prefix_to_consider>"]="<replacement_value>"
+# Where the key 'prefix_to_consider' is the path's prefix that should be replaced
+# with the provided link prefix for the link
+# And the value 'replacement_value' is the source control server link prefix
+#
+# It's advised to set a link prefix pointing to a specific commit sha1 instead of a
+# branch so the links would always points to a meaningful line.
+#
+# Since the syntax is not the same for every source control web servers,
+# the target server type must be specified for each <prefix_to_consider> using
+# the following parameter:
+#     memcheck_url_prefix_replacement_type["<prefix_to_consider>"]="<type>"
+#
+# For now, the following <type> are supported (case does not matter):
+#    - GitHub
+#    - GitLab
+#    - BitBucket
+#
+# For example, setting:
+#    memcheck_url_prefix_replacement["/var/user/repo"]="http://github.com/example/example_project/blob/master/"
+#    memcheck_url_prefix_replacement_type["/var/user/repo"]="github"
+# Would convert the following report line:
+#    ==1==    at 0x10101042: myFunc() (/var/user/repo/src/lib1/MyClass.cpp:14)
+# To:
+#    ==1==    at 0x10101042: myFunc() (<a href="http://github.com/example/example_project/blob/master/src/lib1/MyClass.cpp#L14">/var/user/repo/src/lib1/MyClass.cpp:14</a>)
 #
 # Multiple replacements can be defined
 

--- a/tools/update_test_refs.sh
+++ b/tools/update_test_refs.sh
@@ -20,11 +20,17 @@ for test_ref_dir in "${memcheck_cover_test_dir}/ref/"*; do
     if [ "${test_name}" == "many_result_report" ] || [ "${test_name}" == "no_error_report" ] \
         || [ "${test_name}" == "violation_context_report" ] || [ "${test_name}" == "violation_suppression_report" ]; then
         cp -f "${memcheck_cover_test_dir}out/${test_name}/report/"*html* "${test_ref_dir}"
+    elif [ "${test_name}" == "path_url_link_generation_report" ]; then
+        # All reports are the same for this test, retrieve on of those as ref
+        test_name="${test_name:0: -7}"
+        cp -f "${memcheck_cover_test_dir}out/${test_name}/lower_case_types/report/"*html* "${test_ref_dir}"
     elif [ "${test_name}" == "path_prefix_substitution" ]; then
         for testcase_ref_dir in "${memcheck_cover_test_dir}/ref/${test_name}/"*; do
             test_case_name=$(basename "${testcase_ref_dir}")
             cp -f "${memcheck_cover_test_dir}out/${test_name}/${test_case_name:0: -7}/report/"*html* "${test_ref_dir}/${test_case_name}"
         done
+    elif [ "${test_name}" == "combined_path_substitution_and_url_link_report" ]; then
+        cp -f "${memcheck_cover_test_dir}out/${test_name:0: -7}/report/"*html* "${test_ref_dir}/${test_case_name}"
     else
         test_name="${test_name:0: -7}"
 


### PR DESCRIPTION
It's now possible to use the memcheck_url_prefix_replacement and memcheck_url_prefix_replacement_type associative arrays in the config file to add source control server link prefix for link generation for path prefix.

A comment is now generated in the config file while using the `-g` or `--generate-config option`.

---

Fixes #16 