### PR TITLE
Readme: fixup inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,9 +217,9 @@ The result will look like this:
 ```
 my/output/path/report/
 ├── another_dir/
-│   ├── a_report.memcheck.html.part
-│   └── other_report.memcheck.html.part
-├── filename.memcheck.html.part
+│   ├── a_report.memcheck.html.part.js
+│   └── other_report.memcheck.html.part.js
+├── filename.memcheck.html.part.js
 ├── index.html
 ├── memcheck-cover.css
 └── memcheck-cover.js


### PR DESCRIPTION
The `.html.part` files were renamed to `.html.part.js` due to a wrong
MIME type error in modern web-browsers.

The Readme is now up-to-date with this naming