### PR TITLE
memcheck_runner.sh: Add support for valgrind's error-exitcode option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to the Memcheck-Cover project will be documented in this fil
 
 [Full Changelog](https://github.com/Farigh/memcheck-cover/compare/release-1.2...HEAD)
 
+**New features:**
+  - Add support for Valgrind's `--error-exitcode` option to the `memcheck_runner.sh` script (by @MhmRhm)
+
 ## [v1.2](https://github.com/Farigh/memcheck-cover/releases/tag/release-1.2) (2021-03-14)
 
 [Full Changelog](https://github.com/Farigh/memcheck-cover/compare/release-1.1...release-1.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to the Memcheck-Cover project will be documented in this fil
 
 ## [Unreleased](https://github.com/Farigh/memcheck-cover/tree/HEAD)
 
-[Full Changelog](https://github.com/Farigh/memcheck-cover/compare/release-1.2...HEAD)
+[Full Changelog](https://github.com/Farigh/memcheck-cover/compare/release-1.3...HEAD)
+
+## [v1.3](https://github.com/Farigh/memcheck-cover/releases/tag/release-1.3) (2026-04-25)
+
+[Full Changelog](https://github.com/Farigh/memcheck-cover/compare/release-1.2...release-1.3)
 
 **New features:**
   - Add support for Valgrind's `--error-exitcode` option to the `memcheck_runner.sh` script (by @MhmRhm)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ Info: Running the following cmd with valgrind:
       "true" "can" "take" "useless" "params" "and" "still" "be" "one" "true" "self"
 ```
 
+This call will output the Valgind's report to the `filename.memcheck` file within the `my/output/path/` directory, which in this example was created.\
+The Valgrind analysis was run using the `true` binary, passing it many parameters.
+
 ##### :small_blue_diamond: Valgrind suppressions
 
 You can specify a violation suppression file using the `--ignore` option.\
@@ -82,9 +85,6 @@ The suppression will look like that in the report:
 ==21849==    definitely lost: 4 bytes in 1 blocks
 [...]
 ```
-
-This call will output the Valgind's report to the `filename.memcheck` file within the `my/output/path/` directory, which in this example was created.\
-The Valgrind analysis was run using the `true` binary, passing it many parameters.
 
 ##### :small_blue_diamond: Display sources fullpath
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ Options:
                           (will be suffixed with the .memcheck extension).
   -s|--gen-suppressions   Enables valgrind suppression generation in the output
                           file, those can be used to create a suppression file.
+  --error-exitcode=CODE   Specifies an alternative exit code to return
+                          if Valgrind reported any errors in the run.
+                          When set to the default value (zero),
+                          the return value from Valgrind will always be the
+                          return value of the process being analysed.
   --fullpath-after=       (with nothing after the '=')
                           Show full source paths in call stacks.
   --fullpath-after=STR    Like --fullpath-after=, but only show the part of the
@@ -106,6 +111,20 @@ This facilitates chopping off prefixes when the sources are drawn from a number 
 ```
 
 Passing the `--fullpath-after` to `memcheck_runner.sh` will forward it directly to Valgrind, having the previously described effect.
+
+##### :small_blue_diamond: Error exit code
+
+From [Valgrind's documentation](https://www.valgrind.org/docs/manual/manual-core.html#opt.error-exitcode):
+```
+Specifies an alternative exit code to return if Valgrind reported any errors in the run.
+When set to the default value (zero), the return value from Valgrind will always be the return value of the process being simulated.
+When set to a nonzero value, that value is returned instead, if Valgrind detects any errors.
+This is useful for using Valgrind as part of an automated test suite, since it makes it easy to detect test cases for which Valgrind has reported errors, just by inspecting return codes.
+When set to a nonzero value and Valgrind detects no error, the return value of Valgrind will be the return value of the program being simulated.
+```
+
+Passing the `--error-exitcode` to `memcheck_runner.sh` will forward it directly to Valgrind, having the previously described effect.
+Only the last value is forwarded in case its provided multiple times.
 
 #### :large_orange_diamond: Valgrind's Memcheck tool options
 

--- a/bin/memcheck_runner.sh
+++ b/bin/memcheck_runner.sh
@@ -50,6 +50,11 @@ function print_usage()
     echo "                          (will be suffixed with the .${memcheck_result_ext} extension)."
     echo "  -s|--gen-suppressions   Enables valgrind suppression generation in the output"
     echo "                          file, those can be used to create a suppression file."
+    echo "  --error-exitcode=CODE   Specifies an alternative exit code to return "
+    echo "                          if Valgrind reported any errors in the run."
+    echo "                          When set to the default value (zero),"
+    echo "                          the return value from Valgrind will always be the"
+    echo "                          return value of the process being analysed."
     echo "  --fullpath-after=       (with nothing after the '=')"
     echo "                          Show full source paths in call stacks."
     echo "  --fullpath-after=STR    Like --fullpath-after=, but only show the part of the"
@@ -77,11 +82,20 @@ memcheck_output_name=""
 memcheck_ignore_file=""
 enable_suppression=0
 valgrind_fullpath_after=()
+valgrind_error_exitcode=0
 while getopts ":hi:o:s-:" parsed_option; do
     case "${parsed_option}" in
         # Long options
         -)
             case "${OPTARG}" in
+                error-exitcode)
+                    valgrind_error_exitcode="${!OPTIND}"; ((OPTIND++))
+                    check_param "--error-exitcode" "${valgrind_error_exitcode}"
+                ;;
+                error-exitcode=*)
+                    valgrind_error_exitcode=${OPTARG#*=}
+                    check_param "--error-exitcode" "${valgrind_error_exitcode}"
+                ;;
                 fullpath-after=*)
                     valgrind_fullpath_after+=("${OPTARG#*=}")
                 ;;
@@ -210,6 +224,12 @@ for path in "${valgrind_fullpath_after[@]}"; do
     valgrind_opts+=("--fullpath-after=${path}")
     info "Adding '${path}' to the fullpath-after"
 done
+
+# Add error-exitcode options if asked for
+if [ $valgrind_error_exitcode -ne 0 ]; then
+    valgrind_opts+=("--error-exitcode=${valgrind_error_exitcode}")
+    info "Valgrind error-exitcode set to '${valgrind_error_exitcode}'"
+fi
 
 # Output option
 info "Output file set to: '${memcheck_output_file}'"

--- a/bin/utils.common.sh
+++ b/bin/utils.common.sh
@@ -47,7 +47,7 @@ function info()
 
 function get_memcheck_cover_version()
 {
-    echo "1.2"
+    echo "1.3"
 }
 
 function print_copyright_notice()

--- a/tests/generate_html_outputs_ts/ref/combined_path_substitution_and_url_link_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/combined_path_substitution_and_url_link_report/index.html
@@ -43,7 +43,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/definitely_lost_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/definitely_lost_report/index.html
@@ -39,7 +39,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/fishy_argument_value_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/fishy_argument_value_report/index.html
@@ -39,7 +39,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/illegal_memory_pool_addr_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/illegal_memory_pool_addr_report/index.html
@@ -41,7 +41,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/indirectly_lost_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/indirectly_lost_report/index.html
@@ -39,7 +39,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/invalid_delete_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/invalid_delete_report/index.html
@@ -41,7 +41,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/invalid_read_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/invalid_read_report/index.html
@@ -41,7 +41,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/invalid_write_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/invalid_write_report/index.html
@@ -41,7 +41,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/jump_to_invalid_addr_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/jump_to_invalid_addr_report/index.html
@@ -41,7 +41,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/many_result_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/many_result_report/index.html
@@ -194,7 +194,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/mismatched_delete_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/mismatched_delete_report/index.html
@@ -41,7 +41,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/no_error_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/no_error_report/index.html
@@ -38,7 +38,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/overlapping_blocks_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/overlapping_blocks_report/index.html
@@ -41,7 +41,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/overlapping_src_dest_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/overlapping_src_dest_report/index.html
@@ -39,7 +39,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/path_prefix_substitution/deletion_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/path_prefix_substitution/deletion_report/index.html
@@ -43,7 +43,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/path_prefix_substitution/with_substitution_backquote_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/path_prefix_substitution/with_substitution_backquote_report/index.html
@@ -43,7 +43,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/path_prefix_substitution/with_substitution_backslash_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/path_prefix_substitution/with_substitution_backslash_report/index.html
@@ -43,7 +43,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/path_prefix_substitution/with_substitution_lt_and_gt_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/path_prefix_substitution/with_substitution_lt_and_gt_report/index.html
@@ -43,7 +43,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/path_url_link_generation_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/path_url_link_generation_report/index.html
@@ -43,7 +43,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/possibly_lost_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/possibly_lost_report/index.html
@@ -39,7 +39,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/still_reachable_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/still_reachable_report/index.html
@@ -39,7 +39,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/syscall_param_contains_uninitialized_bytes_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/syscall_param_contains_uninitialized_bytes_report/index.html
@@ -41,7 +41,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/syscall_param_points_to_uninitialized_bytes_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/syscall_param_points_to_uninitialized_bytes_report/index.html
@@ -41,7 +41,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/unaddressable_bytes_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/unaddressable_bytes_report/index.html
@@ -41,7 +41,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/uninitialized_value_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/uninitialized_value_report/index.html
@@ -41,7 +41,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/valgrind_client_checks_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/valgrind_client_checks_report/index.html
@@ -41,7 +41,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/valgrind_warnings_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/valgrind_warnings_report/index.html
@@ -39,7 +39,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/violation_context_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/violation_context_report/index.html
@@ -69,7 +69,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/generate_html_outputs_ts/ref/violation_suppression_report/index.html
+++ b/tests/generate_html_outputs_ts/ref/violation_suppression_report/index.html
@@ -41,7 +41,7 @@
             </div>
             <div class="report_footer">
                 <div class="generation_tool_version">
-                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.2
+                    This report was generated using <a href="https://github.com/Farigh/memcheck-cover">memcheck-cover</a> v1.3
                 </div>
             </div>
         </div>

--- a/tests/runner_params_ts/error_exit_code_param_ts_ptc.sh
+++ b/tests/runner_params_ts/error_exit_code_param_ts_ptc.sh
@@ -1,0 +1,71 @@
+#! /usr/bin/env bash
+
+test_parameter=$1
+
+resolved_script_path=$(readlink -f "$0")
+current_script_dir=$(dirname "${resolved_script_path}")
+current_full_path=$(readlink -e "${current_script_dir}")
+
+test_utils_import=$(readlink -e "${current_full_path}/../utils.test.sh")
+source "${test_utils_import}"
+
+# List cases
+test_cases=(
+    "--error-exitcode "
+    "--error-exitcode="
+)
+
+list_test_cases_option "$1"
+
+############
+### TEST ###
+############
+
+function test_error_exit_code_param()
+{
+    local param_to_test=$1
+    local memcheck_runner="$(get_tools_bin_dir)/memcheck_runner.sh"
+    local test_out_dir=$(get_test_outdir)
+
+    # Use true as it's a simple, 0 returning cmd
+    local test_cmd="true"
+
+    # Create output dir if needed
+    [ ! -d "${test_out_dir}" ] && mkdir -p "${test_out_dir}"
+
+    # Define a different output for each test case
+    local filename_suffix=$(convert_to_filename_str "${param_to_test}")
+    local test_output_prefix="${test_out_dir}test${filename_suffix}"
+    local test_std_output="${test_output_prefix}.out"
+    local test_err_output="${test_output_prefix}.err.out"
+
+    # Call the memcheck runner with its exit-code set to 42
+    local exit_code_value=42
+
+    "${memcheck_runner}" -o"${test_output_prefix}" ${param_to_test}"${exit_code_value}" -- "${test_cmd}" > "${test_std_output}" 2> "${test_err_output}"
+    local test_exit_code=$?
+
+    ### Check test output
+
+    # Expect the output file to be printed
+    expect_output "${test_std_output}" "Info: Valgrind error-exitcode set to '${exit_code_value}'"
+
+    # Followed by the cmd
+    expect_output "${test_std_output}" "Info: Running the following cmd with valgrind:"
+
+    local memcheck_output="${test_output_prefix}.memcheck"
+    expect_file "${memcheck_output}"
+    expect_file_content "${memcheck_output}" "== Command: ${test_cmd}"
+
+    expect_empty_file "${test_err_output}"
+
+    expect_exit_code $test_exit_code 0
+}
+
+# Init global
+error_occured=0
+
+# Run test
+test_error_exit_code_param "${test_parameter}"
+
+exit $error_occured


### PR DESCRIPTION
This update configures the memcheck runner to exit with code 99 when Valgrind detects memory errors. This enables straightforward detection of memcheck failures in CI pipelines, allowing builds to fail automatically if issues are found.

Below is a CMake script example that defines a custom target to run the memcheck runner, generate an HTML report, and propagate the correct exit code:

```cmake
function(AddMemcheck target)
	set(MEMCHECK_PATH ${memcheck-cover_SOURCE_DIR}/bin)
	set(REPORT_PATH "${CMAKE_BINARY_DIR}/valgrind-${target}")
	set(MEMCHECK_SCRIPT [[
		#!/bin/bash
		s=0
		"$1/memcheck_runner.sh" -o "$2/report" -- "$3" || s=$?
		# Run HTML report only if s is 0 or 99
		if [ $s -eq 0 ] || [ $s -eq 99 ]; then
			"$1/generate_html_report.sh" -i "$2" -o "$2"
		fi
		# Report error only if s is 99
		if [ $s -eq 99 ]; then
			echo "❌ Valgrind detected memory errors."
		fi
		# Exit with original status
		exit $s]]
	)
	file(WRITE "${CMAKE_BINARY_DIR}/memcheck_${target}.sh" "${MEMCHECK_SCRIPT}")
	file(CHMOD "${CMAKE_BINARY_DIR}/memcheck_${target}.sh" PERMISSIONS
		OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE
	)
	add_custom_target(memcheck-${target}
		COMMAND ${CMAKE_BINARY_DIR}/memcheck_${target}.sh
			${MEMCHECK_PATH} ${REPORT_PATH} $<TARGET_FILE:${target}>
		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
	)
endfunction()

add_executable(my_test my_test.cpp)
AddMemcheck(my_test)
```